### PR TITLE
安全加固：凭证存储、下载边界与 WebView 来源校验

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         android:allowBackup="false"
         android:icon="@drawable/icon"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@drawable/icon"
         android:supportsRtl="true"
         android:requestLegacyExternalStorage="true"

--- a/app/src/main/kotlin/com/yunx/app/data/db/AppDatabase.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/db/AppDatabase.kt
@@ -6,6 +6,8 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.yunx.app.data.security.AndroidKeystoreCredentialCipher
+import com.yunx.app.data.security.CredentialCipher
 
 @Database(
     entities = [QuarkAccountEntity::class, DownloadTaskEntity::class, UCAccountEntity::class, XunleiAccountEntity::class, BaiduAccountEntity::class, C139AccountEntity::class, Pan123AccountEntity::class],
@@ -14,19 +16,28 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 )
 abstract class AppDatabase : RoomDatabase() {
 
-    abstract fun quarkAccountDao(): QuarkAccountDao
+    abstract fun rawQuarkAccountDao(): QuarkAccountDao
 
     abstract fun downloadTaskDao(): DownloadTaskDao
 
-    abstract fun ucAccountDao(): UCAccountDao
+    abstract fun rawUcAccountDao(): UCAccountDao
 
-    abstract fun xunleiAccountDao(): XunleiAccountDao
+    abstract fun rawXunleiAccountDao(): XunleiAccountDao
 
-    abstract fun baiduAccountDao(): BaiduAccountDao
+    abstract fun rawBaiduAccountDao(): BaiduAccountDao
 
-    abstract fun c139AccountDao(): C139AccountDao
+    abstract fun rawC139AccountDao(): C139AccountDao
 
-    abstract fun pan123AccountDao(): Pan123AccountDao
+    abstract fun rawPan123AccountDao(): Pan123AccountDao
+
+    private lateinit var credentialCipher: CredentialCipher
+
+    fun quarkAccountDao(): QuarkAccountDao = SecureAccountDaos.quark(rawQuarkAccountDao(), credentialCipher)
+    fun ucAccountDao(): UCAccountDao = SecureAccountDaos.uc(rawUcAccountDao(), credentialCipher)
+    fun xunleiAccountDao(): XunleiAccountDao = SecureAccountDaos.xunlei(rawXunleiAccountDao(), credentialCipher)
+    fun baiduAccountDao(): BaiduAccountDao = SecureAccountDaos.baidu(rawBaiduAccountDao(), credentialCipher)
+    fun c139AccountDao(): C139AccountDao = SecureAccountDaos.c139(rawC139AccountDao(), credentialCipher)
+    fun pan123AccountDao(): Pan123AccountDao = SecureAccountDaos.pan123(rawPan123AccountDao(), credentialCipher)
 
     companion object {
         @Volatile
@@ -43,7 +54,10 @@ abstract class AppDatabase : RoomDatabase() {
                     // 早期开发版（1-8）无可靠 schema；从 v9 起必须保留凭证和下载任务
                     .fallbackToDestructiveMigrationFrom(1, 2, 3, 4, 5, 6, 7, 8)
                     .build()
-                    .also { instance = it }
+                    .also { database ->
+                        database.credentialCipher = AndroidKeystoreCredentialCipher()
+                        instance = database
+                    }
             }
 
         private val MIGRATION_9_10 = object : Migration(9, 10) {

--- a/app/src/main/kotlin/com/yunx/app/data/db/DownloadTaskDao.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/db/DownloadTaskDao.kt
@@ -23,6 +23,9 @@ interface DownloadTaskDao {
     @Query("UPDATE download_task SET chunkCount = :chunkCount, plannedTotalSize = :totalSize WHERE id = :id")
     suspend fun updatePlan(id: Long, chunkCount: Int, totalSize: Long)
 
+    @Query("UPDATE download_task SET requestHeadersJson = :encryptedHeaders WHERE id = :id")
+    suspend fun updateRequestHeaders(id: Long, encryptedHeaders: String)
+
     @Query("UPDATE download_task SET status = 2 WHERE status = 1 OR status = 0")
     suspend fun markInterruptedAsPaused()
 

--- a/app/src/main/kotlin/com/yunx/app/data/db/SecureAccountDaos.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/db/SecureAccountDaos.kt
@@ -1,0 +1,143 @@
+package com.yunx.app.data.db
+
+import com.yunx.app.data.security.CredentialCipher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+/** DAO decorators: plaintext is exposed only in memory; every database write is encrypted. */
+internal object SecureAccountDaos {
+    fun quark(raw: QuarkAccountDao, cipher: CredentialCipher): QuarkAccountDao = object : QuarkAccountDao {
+        override fun observeAccount(): Flow<QuarkAccountEntity?> = raw.observeAccount().map { value ->
+            value?.let { decryptQuark(raw, cipher, it) }
+        }
+        override suspend fun upsert(account: QuarkAccountEntity) = raw.upsert(encryptQuark(cipher, account))
+        override suspend fun getAccount(): QuarkAccountEntity? = raw.getAccount()?.let { decryptQuark(raw, cipher, it) }
+        override suspend fun clear() = raw.clear()
+    }
+
+    fun uc(raw: UCAccountDao, cipher: CredentialCipher): UCAccountDao = object : UCAccountDao {
+        override fun observeAccount(): Flow<UCAccountEntity?> = raw.observeAccount().map { value ->
+            value?.let { decryptUc(raw, cipher, it) }
+        }
+        override suspend fun upsert(account: UCAccountEntity) = raw.upsert(encryptUc(cipher, account))
+        override suspend fun getAccount(): UCAccountEntity? = raw.getAccount()?.let { decryptUc(raw, cipher, it) }
+        override suspend fun clear() = raw.clear()
+    }
+
+    fun baidu(raw: BaiduAccountDao, cipher: CredentialCipher): BaiduAccountDao = object : BaiduAccountDao {
+        override fun observeAccount(): Flow<BaiduAccountEntity?> = raw.observeAccount().map { value ->
+            value?.let { decryptBaidu(raw, cipher, it) }
+        }
+        override suspend fun upsert(account: BaiduAccountEntity) = raw.upsert(encryptBaidu(cipher, account))
+        override suspend fun getAccount(): BaiduAccountEntity? = raw.getAccount()?.let { decryptBaidu(raw, cipher, it) }
+        override suspend fun clear() = raw.clear()
+    }
+
+    fun c139(raw: C139AccountDao, cipher: CredentialCipher): C139AccountDao = object : C139AccountDao {
+        override fun observeAccount(): Flow<C139AccountEntity?> = raw.observeAccount().map { value ->
+            value?.let { decryptC139(raw, cipher, it) }
+        }
+        override suspend fun upsert(account: C139AccountEntity) = raw.upsert(encryptC139(cipher, account))
+        override suspend fun getAccount(): C139AccountEntity? = raw.getAccount()?.let { decryptC139(raw, cipher, it) }
+        override suspend fun clear() = raw.clear()
+    }
+
+    fun pan123(raw: Pan123AccountDao, cipher: CredentialCipher): Pan123AccountDao = object : Pan123AccountDao {
+        override fun observeAccount(): Flow<Pan123AccountEntity?> = raw.observeAccount().map { value ->
+            value?.let { decryptPan123(raw, cipher, it) }
+        }
+        override suspend fun upsert(account: Pan123AccountEntity) = raw.upsert(encryptPan123(cipher, account))
+        override suspend fun getAccount(): Pan123AccountEntity? = raw.getAccount()?.let { decryptPan123(raw, cipher, it) }
+        override suspend fun clear() = raw.clear()
+    }
+
+    fun xunlei(raw: XunleiAccountDao, cipher: CredentialCipher): XunleiAccountDao = object : XunleiAccountDao {
+        override fun observeAccount(): Flow<XunleiAccountEntity?> = raw.observeAccount().map { value ->
+            value?.let { decryptXunlei(raw, cipher, it) }
+        }
+        override suspend fun upsert(account: XunleiAccountEntity) = raw.upsert(encryptXunlei(cipher, account))
+        override suspend fun getAccount(): XunleiAccountEntity? = raw.getAccount()?.let { decryptXunlei(raw, cipher, it) }
+        override suspend fun clear() = raw.clear()
+    }
+
+    private suspend fun decryptQuark(raw: QuarkAccountDao, cipher: CredentialCipher, stored: QuarkAccountEntity): QuarkAccountEntity? =
+        decryptOrClear(raw::clear) {
+            val plain = stored.copy(cookie = cipher.decrypt(stored.cookie, "quark.cookie"))
+            if (!cipher.isEncrypted(stored.cookie)) raw.upsert(encryptQuark(cipher, plain))
+            plain
+        }
+
+    private suspend fun decryptUc(raw: UCAccountDao, cipher: CredentialCipher, stored: UCAccountEntity): UCAccountEntity? =
+        decryptOrClear(raw::clear) {
+            val plain = stored.copy(cookie = cipher.decrypt(stored.cookie, "uc.cookie"))
+            if (!cipher.isEncrypted(stored.cookie)) raw.upsert(encryptUc(cipher, plain))
+            plain
+        }
+
+    private suspend fun decryptBaidu(raw: BaiduAccountDao, cipher: CredentialCipher, stored: BaiduAccountEntity): BaiduAccountEntity? =
+        decryptOrClear(raw::clear) {
+            val plain = stored.copy(cookie = cipher.decrypt(stored.cookie, "baidu.cookie"))
+            if (!cipher.isEncrypted(stored.cookie)) raw.upsert(encryptBaidu(cipher, plain))
+            plain
+        }
+
+    private suspend fun decryptC139(raw: C139AccountDao, cipher: CredentialCipher, stored: C139AccountEntity): C139AccountEntity? =
+        decryptOrClear(raw::clear) {
+            val plain = stored.copy(
+                cookie = cipher.decrypt(stored.cookie, "c139.cookie"),
+                authorization = cipher.decrypt(stored.authorization, "c139.authorization")
+            )
+            if (!cipher.isEncrypted(stored.cookie) || !cipher.isEncrypted(stored.authorization)) {
+                raw.upsert(encryptC139(cipher, plain))
+            }
+            plain
+        }
+
+    private suspend fun decryptPan123(raw: Pan123AccountDao, cipher: CredentialCipher, stored: Pan123AccountEntity): Pan123AccountEntity? =
+        decryptOrClear(raw::clear) {
+            val plain = stored.copy(accessToken = cipher.decrypt(stored.accessToken, "pan123.accessToken"))
+            if (!cipher.isEncrypted(stored.accessToken)) raw.upsert(encryptPan123(cipher, plain))
+            plain
+        }
+
+    private suspend fun decryptXunlei(raw: XunleiAccountDao, cipher: CredentialCipher, stored: XunleiAccountEntity): XunleiAccountEntity? =
+        decryptOrClear(raw::clear) {
+            val plain = stored.copy(
+                accessToken = cipher.decrypt(stored.accessToken, "xunlei.accessToken"),
+                refreshToken = cipher.decrypt(stored.refreshToken, "xunlei.refreshToken"),
+                deviceId = cipher.decrypt(stored.deviceId, "xunlei.deviceId"),
+                captchaToken = cipher.decrypt(stored.captchaToken, "xunlei.captchaToken")
+            )
+            if (listOf(stored.accessToken, stored.refreshToken, stored.deviceId, stored.captchaToken).any { !cipher.isEncrypted(it) }) {
+                raw.upsert(encryptXunlei(cipher, plain))
+            }
+            plain
+        }
+
+    private fun encryptQuark(cipher: CredentialCipher, value: QuarkAccountEntity) =
+        value.copy(cookie = cipher.encrypt(value.cookie, "quark.cookie"))
+    private fun encryptUc(cipher: CredentialCipher, value: UCAccountEntity) =
+        value.copy(cookie = cipher.encrypt(value.cookie, "uc.cookie"))
+    private fun encryptBaidu(cipher: CredentialCipher, value: BaiduAccountEntity) =
+        value.copy(cookie = cipher.encrypt(value.cookie, "baidu.cookie"))
+    private fun encryptC139(cipher: CredentialCipher, value: C139AccountEntity) = value.copy(
+        cookie = cipher.encrypt(value.cookie, "c139.cookie"),
+        authorization = cipher.encrypt(value.authorization, "c139.authorization")
+    )
+    private fun encryptPan123(cipher: CredentialCipher, value: Pan123AccountEntity) =
+        value.copy(accessToken = cipher.encrypt(value.accessToken, "pan123.accessToken"))
+    private fun encryptXunlei(cipher: CredentialCipher, value: XunleiAccountEntity) = value.copy(
+        accessToken = cipher.encrypt(value.accessToken, "xunlei.accessToken"),
+        refreshToken = cipher.encrypt(value.refreshToken, "xunlei.refreshToken"),
+        deviceId = cipher.encrypt(value.deviceId, "xunlei.deviceId"),
+        captchaToken = cipher.encrypt(value.captchaToken, "xunlei.captchaToken")
+    )
+
+    private suspend fun <T> decryptOrClear(clear: suspend () -> Unit, block: suspend () -> T): T? =
+        try {
+            block()
+        } catch (error: Exception) {
+            clear()
+            null
+        }
+}

--- a/app/src/main/kotlin/com/yunx/app/data/download/ChunkDownloader.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/download/ChunkDownloader.kt
@@ -1,6 +1,7 @@
 package com.yunx.app.data.download
 
 import android.util.Log
+import com.yunx.app.util.LogRedactor
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -13,6 +14,7 @@ import okhttp3.Request
 import java.io.File
 import java.io.IOException
 import java.io.RandomAccessFile
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.coroutineContext
 import kotlin.math.min
@@ -47,6 +49,8 @@ class ChunkDownloader(private val clientProvider: () -> OkHttpClient) {
 
     /** 任务 id → 该任务当前所有分片请求 */
     private val activeCalls = ConcurrentHashMap<Long, MutableSet<Call>>()
+    private fun newCallSet(): MutableSet<Call> =
+        Collections.newSetFromMap(ConcurrentHashMap<Call, Boolean>())
     fun cancelCalls(taskId: Long) {
         activeCalls.remove(taskId)?.forEach { call -> runCatching { call.cancel() } }
     }
@@ -73,15 +77,21 @@ class ChunkDownloader(private val clientProvider: () -> OkHttpClient) {
             try {
                 runCatching {
                     call.execute().use { response ->
-                        Log.d(TAG, "getTotalSize: range=$withRange code=${response.code} ct=${response.header("Content-Type")} url=${url.take(120)}")
+                        Log.d(TAG, "getTotalSize: range=$withRange code=${response.code} ct=${response.header("Content-Type")} origin=${LogRedactor.url(url)}")
                         // ★ 防盗链/过期/错误页（HTML）直接视为无法取大小，回退流式/单流
                         if (response.header("Content-Type").orEmpty().contains("text/html", ignoreCase = true)) {
                             return@use null
                         }
                         if (!response.isSuccessful) return@use null
-                        response.header("Content-Range")
-                            ?.substringAfter('/')?.toLongOrNull()
-                            ?: response.header("Content-Length")?.toLongOrNull()
+                        if (withRange) {
+                            if (response.code != 206) return@use null
+                            val range = HttpRangePolicy.parse(response.header("Content-Range"))
+                                ?: return@use null
+                            if (range.start != 0L || range.end != 0L) return@use null
+                            range.total
+                        } else {
+                            response.header("Content-Length")?.toLongOrNull()?.takeIf { it > 0 }
+                        }
                     }
                 }.getOrNull()
             } finally { cancelHandle?.dispose() }
@@ -160,7 +170,7 @@ class ChunkDownloader(private val clientProvider: () -> OkHttpClient) {
             .get().build()
 
         val call = client.newCall(request)
-        activeCalls.getOrPut(taskId) { ConcurrentHashMap.newKeySet() }.add(call)
+        activeCalls.getOrPut(taskId) { newCallSet() }.add(call)
         val cancelHandle = coroutineContext[Job]?.invokeOnCompletion { call.cancel() }
         try {
             return call.execute().use { response ->
@@ -171,6 +181,11 @@ class ChunkDownloader(private val clientProvider: () -> OkHttpClient) {
                 }
                 when (val code = response.code) {
                     206 -> {
+                        val requestedEnd = if (unknownTotal) null else end
+                        if (!HttpRangePolicy.matches(response.header("Content-Range"), from, requestedEnd)) {
+                            Log.w(TAG, "downloadChunk: task=$taskId Content-Range 与请求不一致")
+                            return@use ChunkResult.FAILED
+                        }
                         val body = response.body ?: return@use ChunkResult.FAILED
                         val expected = if (unknownTotal) -1L else end - from + 1
                         // 写入分片，严格截断到预期区间
@@ -183,34 +198,8 @@ class ChunkDownloader(private val clientProvider: () -> OkHttpClient) {
                         ChunkResult.OK
                     }
                     200 -> {
-                        // unknownTotal（流式降级，end=MAX）：200 一律视为忽略 Range，由上层回退完整 GET
-                        if (unknownTotal) {
-                            Log.w(TAG, "downloadChunk: task=$taskId 流式下载服务器返回200 → 回退完整GET")
-                            ChunkResult.RANGE_IGNORED
-                        } else {
-                            // ★ 200 可能有两种：① 服务器不支持 Range（回整文件）；② CDN 偶发降级（返回 200，
-                            //   但 Content-Length 与整文件不符，常见于多连接被限流的中间态）。
-                            //   必须校验：Content-Length 缺失或 ≥ 原始区间总长度 → 视为真整文件（RANGE_IGNORED）；
-                            //   否则当 206 处理（writeSlice 按 expected 严格截断，只读本区间字节，不再误退避）。
-                            val cl = response.header("Content-Length")?.toLongOrNull()
-                            val segLen = end - from + 1 + existing  // 原始区间总长度（含已续传部分）= end - start + 1
-                            val isWholeFile = cl == null || cl >= segLen
-                            if (isWholeFile) {
-                                Log.w(TAG, "downloadChunk: task=$taskId range=$from-$end 服务器返回200整文件(CL=$cl) → 触发回退单流")
-                                ChunkResult.RANGE_IGNORED
-                            } else {
-                                // 当 206 处理：只读区间字节（writeSlice 严格截断，天然只写 [from, end]）
-                                val body = response.body ?: return@use ChunkResult.FAILED
-                                val expected = if (unknownTotal) -1L else end - from + 1
-                                val written = writeSlice(body.byteStream(), partFile, existing, expected, onBytes)
-                                if (!unknownTotal && written != expected) {
-                                    Log.w(TAG, "downloadChunk: task=$taskId 200转206写入不足 written=$written 预期=$expected")
-                                    ChunkResult.FAILED
-                                } else {
-                                    ChunkResult.OK
-                                }
-                            }
-                        }
+                        Log.w(TAG, "downloadChunk: task=$taskId Range 请求返回 200，拒绝按分片写入")
+                        ChunkResult.RANGE_IGNORED
                     }
                     else -> {
                         Log.w(TAG, "downloadChunk: task=$taskId 非预期状态码 $code")
@@ -262,14 +251,16 @@ class ChunkDownloader(private val clientProvider: () -> OkHttpClient) {
         total: Long = -1L,
         onBytes: suspend (Long) -> Unit
     ): Boolean = withContext(Dispatchers.IO) {
-        val existing = partFile.length()
-        Log.d(TAG, "downloadFull: task=$taskId 完整下载 url=${url.take(120)} 已有=$existing total=$total")
+        // 完整 GET 的响应从字节 0 开始，必须丢弃任何旧前缀，禁止“旧前缀 + 完整响应”拼接损坏。
+        val existing = 0L
+        if (partFile.exists()) RandomAccessFile(partFile, "rw").use { it.setLength(0) }
+        Log.d(TAG, "downloadFull: task=$taskId 完整下载 origin=${LogRedactor.url(url)} total=$total")
         val request = Request.Builder()
             .url(url)
             .apply { headers.forEach { (k, v) -> header(k, v) } }
             .get().build()
         val call = client.newCall(request)
-        activeCalls.getOrPut(taskId) { ConcurrentHashMap.newKeySet() }.add(call)
+        activeCalls.getOrPut(taskId) { newCallSet() }.add(call)
         val cancelHandle = coroutineContext[Job]?.invokeOnCompletion { call.cancel() }
         try {
             call.execute().use { response ->

--- a/app/src/main/kotlin/com/yunx/app/data/download/DownloadManager.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/download/DownloadManager.kt
@@ -2,8 +2,11 @@ package com.yunx.app.data.download
 
 import android.content.Context
 import android.util.Log
+import com.yunx.app.util.LogRedactor
 import com.yunx.app.data.db.DownloadTaskDao
 import com.yunx.app.data.db.DownloadTaskEntity
+import com.yunx.app.data.security.AndroidKeystoreCredentialCipher
+import com.yunx.app.data.security.CredentialCipher
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -31,6 +34,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import org.json.JSONObject
 import kotlin.coroutines.coroutineContext
 import kotlin.math.ceil
 import kotlin.math.min
@@ -117,6 +121,7 @@ class DownloadManager(
     /** 通知栏显示下载速度开关（false 时仅显示通知，隐藏速度） */
     private val showSpeedProvider: () -> Boolean = { true }
 ) {
+    private val credentialCipher: CredentialCipher = AndroidKeystoreCredentialCipher()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     /** 当前实际下载中的任务数（用于最大同时下载任务数限制） */
@@ -206,11 +211,12 @@ class DownloadManager(
             url.substringAfterLast('/').substringBefore('?')
                 .ifBlank { "download_${System.currentTimeMillis()}" }
         }
-        Log.d(TAG, "enqueue: url=$url fileName=$safeName headers=${headers.keys} size=$size")
+        Log.d(TAG, "enqueue: origin=${LogRedactor.url(url)} fileName=$safeName headers=${headers.keys} size=$size")
         val id = dao.insert(
             DownloadTaskEntity(
                 url = url,
-                fileName = safeName
+                fileName = safeName,
+                requestHeadersJson = encodeHeaders(headers)
             )
         )
         // 保存请求头（Cookie/UA），暂停后恢复仍需携带
@@ -245,7 +251,13 @@ class DownloadManager(
                     onTaskStarted(id)
                     // 任务级互斥：同一任务串行执行，暂停后立刻恢复不会并发写分片
                     taskLocks.getOrPut(id) { Mutex() }.withLock {
-                        runTaskWithRetry(id, effectiveHeaders)
+                        val restoredHeaders = if (effectiveHeaders.isNotEmpty()) {
+                            effectiveHeaders
+                        } else {
+                            loadPersistedHeaders(id)
+                        }
+                        if (restoredHeaders.isNotEmpty()) taskHeaders[id] = restoredHeaders
+                        runTaskWithRetry(id, restoredHeaders)
                     }
                 } catch (e: CancellationException) {
                     // 主动暂停/删除：part 文件保留（或由 remove 清理）；状态已由调用方设置
@@ -378,6 +390,30 @@ class DownloadManager(
 
     // ---------- 内部实现 ----------
 
+    private fun encodeHeaders(headers: Map<String, String>): String {
+        val json = JSONObject().apply { headers.forEach { (name, value) -> put(name, value) } }.toString()
+        return credentialCipher.encrypt(json, "download.requestHeaders")
+    }
+
+    private suspend fun loadPersistedHeaders(id: Long): Map<String, String> {
+        val stored = dao.get(id)?.requestHeadersJson.orEmpty()
+        if (stored.isBlank()) return emptyMap()
+        return runCatching {
+            val jsonText = credentialCipher.decrypt(stored, "download.requestHeaders")
+            val json = JSONObject(jsonText)
+            buildMap {
+                json.keys().forEach { name -> put(name, json.getString(name)) }
+            }.also {
+                if (!credentialCipher.isEncrypted(stored)) {
+                    dao.updateRequestHeaders(id, encodeHeaders(it))
+                }
+            }
+        }.getOrElse {
+            dao.updateRequestHeaders(id, encodeHeaders(emptyMap()))
+            emptyMap()
+        }
+    }
+
     /** 当前协程是否仍活跃（暂停/删除触发取消后为 false） */
     private suspend fun isTaskActive(): Boolean = coroutineContext[Job]?.isActive == true
 
@@ -432,7 +468,7 @@ class DownloadManager(
 
         // HLS（m3u8 转码流，如 UC play）：不走 Range 分片，直接拉分片合并
         if (task.url.contains(".m3u8", true) || task.url.contains(".m3u", true)) {
-            Log.d(TAG, "runTask: id=$id HLS 转码流下载 url=${task.url.take(120)}")
+            Log.d(TAG, "runTask: id=$id HLS 转码流下载 origin=${LogRedactor.url(task.url)}")
             hlsDownload(id, task, headers)
             return
         }
@@ -443,11 +479,11 @@ class DownloadManager(
             ?: taskSizes[id]?.takeIf { it > 0 }
         if (total == null) {
             // 服务器不返回文件大小（Range/Content-Length 均缺失）：降级为流式下载（开放区间 Range）
-            Log.w(TAG, "runTask: id=$id 无法获取总大小，降级流式下载 url=${task.url.take(120)}")
+            Log.w(TAG, "runTask: id=$id 无法获取总大小，降级流式下载 origin=${LogRedactor.url(task.url)}")
             streamDownload(id, task, headers)
             return
         }
-        Log.d(TAG, "getTotalSize: id=$id total=$total url=${task.url.take(120)}")
+        Log.d(TAG, "getTotalSize: id=$id total=$total origin=${LogRedactor.url(task.url)}")
         dao.updateProgress(id, DownloadTaskEntity.STATUS_DOWNLOADING, task.downloadedSize, total)
         // 取到大小后再次检查取消（暂停可能发生在 getTotalSize 期间）
         if (!isTaskActive()) return
@@ -788,6 +824,8 @@ class DownloadManager(
         if (ok != ChunkResult.OK) {
             // Range 被 CDN 拒绝（416/403）或忽略（200 整文件）：回退为无 Range 完整 GET
             Log.w(TAG, "streamDownload: id=$id Range 失败，回退完整 GET 下载")
+            downloaded.set(0)
+            dao.updateProgress(id, DownloadTaskEntity.STATUS_DOWNLOADING, 0, 0)
             val ok2 = downloader.downloadFull(
                 taskId = id,
                 url = task.url,

--- a/app/src/main/kotlin/com/yunx/app/data/download/DownloadPathPolicy.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/download/DownloadPathPolicy.kt
@@ -1,0 +1,42 @@
+package com.yunx.app.data.download
+
+import java.io.File
+
+/** Pure path validation shared by Android storage backends and unit tests. */
+internal object DownloadPathPolicy {
+
+    data class SafePath(val fileName: String, val relativeDirectory: String)
+
+    fun sanitize(relativePath: String, fallbackName: String): SafePath? {
+        val normalized = relativePath.replace('\\', '/')
+        if (normalized.startsWith('/')) return null
+
+        val rawParts = normalized.split('/')
+        if (rawParts.any { it == "." || it == ".." }) return null
+
+        val parts = rawParts.filter { it.isNotBlank() }
+        val rawName = parts.lastOrNull().orEmpty()
+        val safeName = sanitizeName(rawName).ifBlank { fallbackName }
+        val safeDirectory = parts.dropLast(1)
+            .joinToString("/") { sanitizeName(it) }
+        return SafePath(safeName, safeDirectory)
+    }
+
+    fun isContained(base: File, candidate: File): Boolean {
+        val basePath = base.canonicalFile.path.trimEnd(File.separatorChar)
+        val candidatePath = candidate.canonicalFile.path
+        return candidatePath != basePath && candidatePath.startsWith(basePath + File.separator)
+    }
+
+    fun sanitizeName(name: String): String {
+        var cleaned = name
+            .replace(Regex("[\\\\/:*?\"<>|\\x00-\\x1f]"), "_")
+            .trim()
+        if (cleaned.length > 120) {
+            val ext = cleaned.substringAfterLast('.', "").take(10)
+            val base = cleaned.substringBeforeLast('.').take(100)
+            cleaned = if (ext.isNotBlank() && ext != cleaned) "$base.$ext" else cleaned.take(120)
+        }
+        return cleaned
+    }
+}

--- a/app/src/main/kotlin/com/yunx/app/data/download/DownloadSaver.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/download/DownloadSaver.kt
@@ -1,7 +1,6 @@
 package com.yunx.app.data.download
 
 import android.content.ContentResolver
-import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Context
 import android.os.Build
@@ -9,6 +8,7 @@ import android.os.Environment
 import android.provider.DocumentsContract
 import android.provider.MediaStore
 import android.util.Log
+import androidx.annotation.RequiresApi
 import java.io.File
 
 /**
@@ -32,14 +32,15 @@ object DownloadSaver {
      * @return 保存成功后的标识（MediaStore uri 字符串 / SAF 文档 uri / 文件绝对路径）；失败返回 null
      */
     fun save(context: Context, fileName: String, source: File, targetDirUri: String? = null): String? {
-        // 拆分相对路径与文件名：目录段与文件名分别清洗
-        val clean = fileName.replace('\\', '/')
-        val slash = clean.lastIndexOf('/')
-        val dirRel = if (slash > 0) clean.substring(0, slash) else ""
-        val baseName = if (slash >= 0) clean.substring(slash + 1) else clean
-        val safeName = sanitizeFileName(baseName)
-        val safeDir = dirRel.split('/').filter { it.isNotBlank() }
-            .joinToString("/") { sanitizeFileName(it) }
+        val safePath = DownloadPathPolicy.sanitize(
+            fileName,
+            fallbackName = "download_${System.currentTimeMillis()}"
+        ) ?: run {
+            Log.e(TAG, "拒绝不安全的下载相对路径")
+            return null
+        }
+        val safeName = safePath.fileName
+        val safeDir = safePath.relativeDirectory
         // 自定义 SAF 目录：优先走系统文档树（适配 Android 10/11+ 分区存储与 Android 9-，无需额外存储权限）
         if (!targetDirUri.isNullOrBlank()) {
             return saveViaSaf(context, safeName, safeDir, source, targetDirUri)
@@ -153,25 +154,13 @@ object DownloadSaver {
         }.getOrDefault("自定义目录")
     }
 
-    /** 清洗文件名：非法字符替换为下划线，超长截断（保留扩展名），空名兜底 */
-    private fun sanitizeFileName(name: String): String {
-        var cleaned = name
-            .replace(Regex("[\\\\/:*?\"<>|\\x00-\\x1f]"), "_")
-            .trim()
-        if (cleaned.length > 120) {
-            val ext = cleaned.substringAfterLast('.', "").take(10)
-            val base = cleaned.substringBeforeLast('.').take(100)
-            cleaned = if (ext.isNotBlank() && ext != cleaned) "$base.$ext" else cleaned.take(120)
-        }
-        return cleaned.ifBlank { "download_${System.currentTimeMillis()}" }
-    }
-
     /**
      * MediaStore.Downloads 保存：
-     * 1. 保存前清理同路径同名残留记录（幽灵文件：文件已删但数据库仍在，部分 ROM 同名 insert 会返回 null）；
-     * 2. 原名 insert → 失败则在扩展名前加时间戳防重（最多 3 次，绕过幽灵/同名约束）；
+     * 1. 从原名开始尝试，已存在时跳过，绝不预删用户文件；
+     * 2. 冲突或 insert 失败则在扩展名前加时间戳防重（最多 3 次）；
      * 3. 均失败返回 null（上层报错，不再兜底私有目录）。
      */
+    @RequiresApi(Build.VERSION_CODES.Q)
     private fun saveViaMediaStore(context: Context, fileName: String, subDir: String, source: File): String? {
         val resolver = context.contentResolver
         val relativePath = if (subDir.isBlank()) {
@@ -179,8 +168,6 @@ object DownloadSaver {
         } else {
             "${Environment.DIRECTORY_DOWNLOADS}/$subDir"
         }
-        // 幽灵文件处理：保存前先清理同名残留记录
-        removeMediaStoreDuplicates(resolver, fileName, relativePath)
         // 候选：原名 → 时间戳防重名（base.apk → base_20260812165000.apk → base_..._2.apk）
         val candidates = buildList {
             add(fileName)
@@ -188,7 +175,7 @@ object DownloadSaver {
         }
         for (candidate in candidates) {
             try {
-                removeMediaStoreDuplicates(resolver, candidate, relativePath)
+                if (mediaStoreNameExists(resolver, candidate, relativePath)) continue
                 val values = ContentValues().apply {
                     put(MediaStore.Downloads.DISPLAY_NAME, candidate)
                     put(MediaStore.Downloads.MIME_TYPE, mimeOf(candidate))
@@ -224,16 +211,13 @@ object DownloadSaver {
         return if (attempt == 0) "${base}_$ts$ext" else "${base}_${ts}_${attempt + 1}$ext"
     }
 
-    /**
-     * 清理 MediaStore 中指定路径下的同名记录（幽灵文件：文件已删但数据库残留）。
-     * 只删数据库记录及对应文件（若仍存在）；随后可安全插入同名新记录。
-     */
-    private fun removeMediaStoreDuplicates(
+    /** 同路径同名对象存在时换一个候选名，绝不删除既有内容。 */
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun mediaStoreNameExists(
         resolver: ContentResolver,
         fileName: String,
         relativePath: String
-    ) {
-        runCatching {
+    ): Boolean = runCatching {
             val selection = "${MediaStore.Downloads.DISPLAY_NAME}=? AND ${MediaStore.Downloads.RELATIVE_PATH}=?"
             val projection = arrayOf(MediaStore.Downloads._ID)
             resolver.query(
@@ -243,23 +227,28 @@ object DownloadSaver {
                 arrayOf(fileName, relativePath),
                 null
             )?.use { cursor ->
-                while (cursor.moveToNext()) {
-                    val id = cursor.getLong(0)
-                    val uri = ContentUris.withAppendedId(MediaStore.Downloads.EXTERNAL_CONTENT_URI, id)
-                    resolver.delete(uri, null, null)
-                }
-            }
-        }.onFailure {
-            Log.e(TAG, "清理 MediaStore 同名记录失败: ${it.message}")
-        }
-    }
+                cursor.moveToFirst()
+            } ?: false
+        }.onFailure { Log.e(TAG, "查询 MediaStore 同名记录失败: ${it.message}") }
+            .getOrDefault(true)
 
     private fun saveLegacy(context: Context, fileName: String, subDir: String, source: File): String? = runCatching {
-        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-        val destDir = if (subDir.isBlank()) dir else File(dir, subDir)
+        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).canonicalFile
+        val destDir = (if (subDir.isBlank()) dir else File(dir, subDir)).canonicalFile
+        if (destDir != dir && !DownloadPathPolicy.isContained(dir, destDir)) {
+            throw SecurityException("下载目录越界")
+        }
         if (!destDir.exists()) destDir.mkdirs()
-        val dest = File(destDir, fileName)
-        source.copyTo(dest, overwrite = true)
+        val candidates = buildList {
+            add(fileName)
+            repeat(3) { i -> add(timestampedName(fileName, i)) }
+        }
+        val dest = candidates.asSequence()
+            .map { File(destDir, it).canonicalFile }
+            .firstOrNull { candidate ->
+                DownloadPathPolicy.isContained(dir, candidate) && !candidate.exists()
+            } ?: return@runCatching null
+        source.copyTo(dest, overwrite = false)
         dest.absolutePath
     }.getOrNull()
 

--- a/app/src/main/kotlin/com/yunx/app/data/download/HlsDownloader.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/download/HlsDownloader.kt
@@ -3,126 +3,233 @@ package com.yunx.app.data.download
 import android.util.Log
 import com.yunx.app.data.network.HttpClients
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl
 import okhttp3.Request
+import okhttp3.Response
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
+import java.io.OutputStream
 import kotlin.coroutines.coroutineContext
 
-/**
- * 轻量 HLS 下载器（UC play 转码流，绕过非会员视频被换成宣传片的问题）：
- * - 支持 master playlist（自动选第一个 #EXT-X-STREAM-INF 子流）与 media playlist；
- * - .ts 分片直接拼接；fMP4 按 #EXT-X-MAP 的 init 段 + 分片顺序拼接；
- * - 不支持 AES 加密（#EXT-X-KEY）与 #EXT-X-BYTERANGE（返回 false，由上层回退 OSS 直链）。
- */
+/** Bounded HLS downloader that never forwards credentials across origins. */
 object HlsDownloader {
-
     private const val TAG = "YunX-HLS"
+    private const val MAX_REDIRECTS = 5
+    private const val MAX_PLAYLIST_BYTES = 1024 * 1024L
+    private const val MAX_SEGMENTS = 20_000
+    private const val MAX_SEGMENT_BYTES = 512L * 1024 * 1024
+    private const val MAX_TOTAL_BYTES = 100L * 1024 * 1024 * 1024
+    private const val COPY_BUFFER_SIZE = 64 * 1024
 
-    private val client get() = HttpClients.apiClient()
+    // Redirects are handled here so a cross-origin hop cannot inherit Cookie/Authorization.
+    private val client get() = HttpClients.apiClient().newBuilder()
+        .followRedirects(false)
+        .followSslRedirects(false)
+        .build()
 
-    /**
-     * 下载 m3u8 转码流并合并为单个文件（mp4/ts）。
-     * @param onBytes 每下载一段分片回调新增字节数（suspend，可做进度上报）
-     * @return 是否成功
-     */
     suspend fun download(
         url: String,
         headers: Map<String, String>,
         destFile: File,
         onBytes: suspend (Long) -> Unit
     ): Boolean = withContext(Dispatchers.IO) {
+        val credentialOrigin = HlsRequestPolicy.initialUrl(url) ?: run {
+            Log.w(TAG, "拒绝非 HTTPS 或无效的 HLS 地址")
+            return@withContext false
+        }
+
         runCatching {
-            val playlist = fetchText(url, headers) ?: return@runCatching false
-            val mediaUrl = resolveMediaPlaylist(url, playlist) ?: return@runCatching false
-            val mediaText = if (mediaUrl == url) playlist else fetchText(mediaUrl, headers) ?: return@runCatching false
-            // AES 加密不支持
-            if (mediaText.contains("#EXT-X-KEY")) {
-                Log.w(TAG, "HLS 含 AES 加密，暂不支持")
+            val master = fetchText(credentialOrigin, credentialOrigin, headers) ?: return@runCatching false
+            val mediaUrl = resolveMediaPlaylist(master.finalUrl, master.text) ?: return@runCatching false
+            val media = if (mediaUrl == master.finalUrl) master
+            else fetchText(mediaUrl, credentialOrigin, headers) ?: return@runCatching false
+
+            if (media.text.contains("#EXT-X-KEY") || media.text.contains("#EXT-X-BYTERANGE")) {
+                Log.w(TAG, "HLS 含不支持的加密或 BYTERANGE")
                 return@runCatching false
             }
-            val base = mediaUrl.substringBeforeLast('/', "") + "/"
-            val initUri = parseMapUri(mediaText)?.let { resolveUri(base, it) }
-            val segments = parseSegments(mediaText).mapNotNull { resolveUri(base, it) }
-            if (segments.isEmpty()) {
-                Log.w(TAG, "HLS 分片列表为空")
-                return@runCatching false
+
+            val initUri = parseMapUri(media.text)?.let { HlsRequestPolicy.resolve(media.finalUrl, it) }
+            val rawSegments = parseSegments(media.text)
+            if (rawSegments.isEmpty()) return@runCatching false
+            val segments = rawSegments.map { raw ->
+                HlsRequestPolicy.resolve(media.finalUrl, raw)
+                    ?: throw IllegalArgumentException("HLS 分片地址不是受支持的 HTTPS URL")
             }
+
             destFile.parentFile?.mkdirs()
-            FileOutputStream(destFile).use { out ->
-                // 先写 init 段（fMP4 需要）
-                if (initUri != null) {
-                    val initBytes = fetchBytes(initUri, headers) ?: return@runCatching false
-                    out.write(initBytes)
-                }
+            FileOutputStream(destFile, false).use { out ->
                 var total = 0L
-                segments.forEachIndexed { idx, seg ->
-                    val bytes = fetchBytes(seg, headers) ?: return@runCatching false
-                    out.write(bytes)
-                    total += bytes.size
-                    onBytes(bytes.size.toLong())
-                    if (idx % 10 == 0) Log.d(TAG, "HLS 分片 ${idx + 1}/${segments.size}")
+                if (initUri != null) {
+                    val wrote = fetchTo(initUri, credentialOrigin, headers, out, MAX_SEGMENT_BYTES) { bytes ->
+                        total = checkedTotal(total, bytes)
+                        onBytes(bytes)
+                    } ?: return@runCatching false
+                    if (wrote <= 0) return@runCatching false
+                }
+                segments.forEachIndexed { index, segment ->
+                    val wrote = fetchTo(segment, credentialOrigin, headers, out, MAX_SEGMENT_BYTES) { bytes ->
+                        total = checkedTotal(total, bytes)
+                        onBytes(bytes)
+                    } ?: return@runCatching false
+                    if (wrote <= 0) return@runCatching false
+                    if (index % 10 == 0) Log.d(TAG, "HLS 分片 ${index + 1}/${segments.size}")
                 }
                 Log.d(TAG, "HLS 下载完成 segments=${segments.size} size=$total")
             }
             true
-        }.getOrElse {
+        }.onFailure {
             Log.e(TAG, "HLS 下载失败: ${it.message}")
-            false
+        }.getOrDefault(false).also { success ->
+            if (!success) destFile.delete()
         }
     }
 
-    private suspend fun fetchText(url: String, headers: Map<String, String>): String? = runCatching {
-        val req = Request.Builder().url(url).apply { headers.forEach { (k, v) -> header(k, v) } }.get().build()
-        executeCancellable(req) { resp -> if (resp.isSuccessful) resp.body?.string() else null }
-    }.getOrNull()
+    private data class FetchedText(val finalUrl: HttpUrl, val text: String)
 
-    private suspend fun fetchBytes(url: String, headers: Map<String, String>): ByteArray? = runCatching {
-        val req = Request.Builder().url(url).apply { headers.forEach { (k, v) -> header(k, v) } }.get().build()
-        executeCancellable(req) { resp -> if (resp.isSuccessful) resp.body?.bytes() else null }
-    }.getOrNull()
+    private suspend fun fetchText(
+        startUrl: HttpUrl,
+        credentialOrigin: HttpUrl,
+        headers: Map<String, String>
+    ): FetchedText? {
+        var current = startUrl
+        repeat(MAX_REDIRECTS + 1) { redirectCount ->
+            val result = executeCancellable(requestFor(current, credentialOrigin, headers)) { response ->
+                redirectTarget(response, current)?.let { return@executeCancellable it to null }
+                if (!response.isSuccessful) return@executeCancellable null
+                val body = response.body ?: return@executeCancellable null
+                null to readBoundedText(body.byteStream(), body.contentLength())
+            } ?: return null
+            val redirect = result.first
+            if (redirect == null) return FetchedText(current, result.second ?: return null)
+            if (redirectCount >= MAX_REDIRECTS) return null
+            current = redirect
+        }
+        return null
+    }
 
-    private suspend fun <T> executeCancellable(request: Request, block: (okhttp3.Response) -> T): T {
+    private suspend fun fetchTo(
+        startUrl: HttpUrl,
+        credentialOrigin: HttpUrl,
+        headers: Map<String, String>,
+        output: OutputStream,
+        maxBytes: Long,
+        onBytes: suspend (Long) -> Unit
+    ): Long? {
+        var current = startUrl
+        repeat(MAX_REDIRECTS + 1) { redirectCount ->
+            val result = executeCancellable(requestFor(current, credentialOrigin, headers)) { response ->
+                redirectTarget(response, current)?.let { return@executeCancellable it to null }
+                if (!response.isSuccessful) return@executeCancellable null
+                val body = response.body ?: return@executeCancellable null
+                if (body.contentLength() > maxBytes) throw IllegalStateException("HLS 分片超过大小限制")
+                var written = 0L
+                val buffer = ByteArray(COPY_BUFFER_SIZE)
+                body.byteStream().use { input ->
+                    while (true) {
+                        val count = input.read(buffer)
+                        if (count < 0) break
+                        if (count == 0) continue
+                        written += count
+                        if (written > maxBytes) throw IllegalStateException("HLS 分片超过大小限制")
+                        output.write(buffer, 0, count)
+                        onBytes(count.toLong())
+                    }
+                }
+                null to written
+            } ?: return null
+            val redirect = result.first
+            if (redirect == null) return result.second
+            if (redirectCount >= MAX_REDIRECTS) return null
+            current = redirect
+        }
+        return null
+    }
+
+    private fun requestFor(
+        target: HttpUrl,
+        credentialOrigin: HttpUrl,
+        headers: Map<String, String>
+    ): Request = Request.Builder()
+        .url(target)
+        .apply {
+            HlsRequestPolicy.headersFor(target, credentialOrigin, headers)
+                .forEach { (name, value) -> header(name, value) }
+        }
+        .get()
+        .build()
+
+    private fun redirectTarget(response: Response, current: HttpUrl): HttpUrl? {
+        if (response.code !in 300..399) return null
+        val location = response.header("Location") ?: return null
+        return HlsRequestPolicy.resolve(current, location)
+            ?: throw IllegalArgumentException("HLS 重定向到非 HTTPS 地址")
+    }
+
+    private suspend fun <T> executeCancellable(request: Request, block: suspend (Response) -> T): T {
         val call = client.newCall(request)
         val cancelHandle = coroutineContext[Job]?.invokeOnCompletion { call.cancel() }
+        val response = call.execute()
         return try {
-            call.execute().use(block)
+            block(response)
         } finally {
+            response.close()
             cancelHandle?.dispose()
         }
     }
 
-    /** 若为 master playlist（含 #EXT-X-STREAM-INF），返回第一个子流 URL；否则原样返回 */
-    private fun resolveMediaPlaylist(playlistUrl: String, text: String): String? {
-        val base = playlistUrl.substringBeforeLast('/', "") + "/"
-        val lines = text.lines()
-        for (i in lines.indices) {
-            if (lines[i].startsWith("#EXT-X-STREAM-INF")) {
-                val next = lines.getOrNull(i + 1)?.trim() ?: continue
-                if (next.isNotBlank() && !next.startsWith("#")) return resolveUri(base, next)
+    private fun readBoundedText(input: java.io.InputStream, declaredLength: Long): String {
+        if (declaredLength > MAX_PLAYLIST_BYTES) throw IllegalStateException("HLS 播放列表超过大小限制")
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(16 * 1024)
+        input.use {
+            while (true) {
+                val count = it.read(buffer)
+                if (count < 0) break
+                if (count == 0) continue
+                if (output.size().toLong() + count > MAX_PLAYLIST_BYTES) {
+                    throw IllegalStateException("HLS 播放列表超过大小限制")
+                }
+                output.write(buffer, 0, count)
+            }
+        }
+        return output.toString(Charsets.UTF_8.name())
+    }
+
+    private fun checkedTotal(current: Long, added: Long): Long {
+        val total = Math.addExact(current, added)
+        if (total > MAX_TOTAL_BYTES) throw IllegalStateException("HLS 总下载量超过限制")
+        return total
+    }
+
+    private fun resolveMediaPlaylist(playlistUrl: HttpUrl, text: String): HttpUrl? {
+        val lines = text.lineSequence().toList()
+        for (index in lines.indices) {
+            if (lines[index].startsWith("#EXT-X-STREAM-INF")) {
+                val next = lines.getOrNull(index + 1)?.trim() ?: continue
+                if (next.isNotBlank() && !next.startsWith("#")) {
+                    return HlsRequestPolicy.resolve(playlistUrl, next)
+                }
             }
         }
         return playlistUrl
     }
 
-    /** 解析 media playlist 的分片 URI（非 # 开头的行，过滤 #EXTINF 等标签） */
     private fun parseSegments(text: String): List<String> = buildList {
-        val lines = text.lines()
-        for (line in lines) {
-            val t = line.trim()
-            if (t.isNotBlank() && !t.startsWith("#")) add(t)
+        for (line in text.lineSequence()) {
+            val value = line.trim()
+            if (value.isNotBlank() && !value.startsWith("#")) {
+                if (size >= MAX_SEGMENTS) throw IllegalStateException("HLS 分片数量超过限制")
+                add(value)
+            }
         }
     }
 
-    /** 解析 #EXT-X-MAP:URI="init.mp4" 的 init 段地址（fMP4） */
     private fun parseMapUri(text: String): String? {
-        val line = text.lines().firstOrNull { it.startsWith("#EXT-X-MAP") } ?: return null
-        val m = Regex("""URI="([^"]+)"""").find(line) ?: return null
-        return m.groupValues[1]
+        val line = text.lineSequence().firstOrNull { it.startsWith("#EXT-X-MAP") } ?: return null
+        return Regex("""URI="([^"]+)"""").find(line)?.groupValues?.get(1)
     }
-
-    /** 相对地址解析（相对于 m3u8 所在目录） */
-    private fun resolveUri(base: String, uri: String): String =
-        if (uri.startsWith("http")) uri else base + uri
 }

--- a/app/src/main/kotlin/com/yunx/app/data/download/HlsRequestPolicy.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/download/HlsRequestPolicy.kt
@@ -1,0 +1,29 @@
+package com.yunx.app.data.download
+
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+
+/** Origin and header policy for every playlist, redirect, map and segment request. */
+internal object HlsRequestPolicy {
+    private val sensitiveHeaders = setOf(
+        "authorization", "cookie", "origin", "proxy-authorization", "referer"
+    )
+
+    fun initialUrl(url: String): HttpUrl? =
+        url.toHttpUrlOrNull()?.takeIf { it.isHttps }
+
+    fun resolve(base: HttpUrl, candidate: String): HttpUrl? =
+        base.resolve(candidate)?.takeIf { it.isHttps }
+
+    fun headersFor(
+        target: HttpUrl,
+        credentialOrigin: HttpUrl,
+        headers: Map<String, String>
+    ): Map<String, String> {
+        if (sameOrigin(target, credentialOrigin)) return headers
+        return headers.filterKeys { it.lowercase() !in sensitiveHeaders }
+    }
+
+    fun sameOrigin(left: HttpUrl, right: HttpUrl): Boolean =
+        left.scheme == right.scheme && left.host == right.host && left.port == right.port
+}

--- a/app/src/main/kotlin/com/yunx/app/data/download/HttpRangePolicy.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/download/HttpRangePolicy.kt
@@ -1,0 +1,22 @@
+package com.yunx.app.data.download
+
+internal object HttpRangePolicy {
+    data class ContentRange(val start: Long, val end: Long, val total: Long?)
+
+    private val pattern = Regex("""bytes\s+(\d+)-(\d+)/(\d+|\*)""", RegexOption.IGNORE_CASE)
+
+    fun parse(value: String?): ContentRange? {
+        val match = pattern.matchEntire(value?.trim().orEmpty()) ?: return null
+        val start = match.groupValues[1].toLongOrNull() ?: return null
+        val end = match.groupValues[2].toLongOrNull() ?: return null
+        val total = match.groupValues[3].takeUnless { it == "*" }?.toLongOrNull()
+        if (start < 0 || end < start || (total != null && end >= total)) return null
+        return ContentRange(start, end, total)
+    }
+
+    fun matches(value: String?, requestedStart: Long, requestedEnd: Long?): Boolean {
+        val range = parse(value) ?: return false
+        if (range.start != requestedStart) return false
+        return requestedEnd == null || range.end == requestedEnd
+    }
+}

--- a/app/src/main/kotlin/com/yunx/app/data/network/HttpClients.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/network/HttpClients.kt
@@ -4,30 +4,15 @@ import okhttp3.ConnectionPool
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
-import java.security.SecureRandom
-import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
-import javax.net.ssl.SSLContext
-import javax.net.ssl.TrustManager
-import javax.net.ssl.X509TrustManager
 
 /**
  * 全局 HTTP 客户端管理：
  * - [apiClient]：平台 API（登录/解析/直链）、HLS 下载、更新检查共用，超时宽松；
  * - [downloadClient]：分片下载专用，大 Dispatcher 保障分片并发（默认实例 maxRequestsPerHost=5 会锁死并发）。
- *
- * 两套客户端均支持「忽略 SSL 证书校验」：开关切换后重建缓存实例即时生效，
- * 各调用方通过 Provider 动态获取，无需重启应用（用于抓包调试）。
+ * 所有构建都使用系统证书链和 OkHttp 主机名校验，不提供进程内绕过开关。
  */
 object HttpClients {
-
-    /** 忽略 SSL 证书校验（抓包调试用，仅设置页隐藏菜单可开） */
-    @Volatile
-    var ignoreSsl: Boolean = false
-        set(value) {
-            field = value
-            rebuildAll()
-        }
 
     private val lock = Any()
 
@@ -55,22 +40,13 @@ object HttpClients {
         }
     }
 
-    /** 开关变化：丢弃缓存，下次获取时按新配置重建 */
-    private fun rebuildAll() {
-        synchronized(lock) {
-            apiCache = null
-            downloadCache = null
-        }
-    }
-
     private fun buildApi(): OkHttpClient {
-        val builder = OkHttpClient.Builder()
+        return OkHttpClient.Builder()
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
             .retryOnConnectionFailure(true)
-        if (ignoreSsl) applyIgnoreSsl(builder)
-        return builder.build()
+            .build()
     }
 
     private fun buildDownload(): OkHttpClient {
@@ -78,7 +54,7 @@ object HttpClients {
             maxRequests = 512
             maxRequestsPerHost = 512 // 与设置页线程数上限（512）对齐，不锁死并发
         }
-        val builder = OkHttpClient.Builder()
+        return OkHttpClient.Builder()
             .dispatcher(dispatcher)
             .connectionPool(
                 ConnectionPool(
@@ -92,20 +68,6 @@ object HttpClients {
             .readTimeout(60, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)
             .retryOnConnectionFailure(true)
-        if (ignoreSsl) applyIgnoreSsl(builder)
-        return builder.build()
-    }
-
-    /** 注入「信任所有证书」的 TrustManager + 放行所有 Hostname（仅抓包调试） */
-    private fun applyIgnoreSsl(builder: OkHttpClient.Builder) {
-        val trustAll = arrayOf<TrustManager>(object : X509TrustManager {
-            override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {}
-            override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {}
-            override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
-        })
-        val sslContext = SSLContext.getInstance("TLS")
-        sslContext.init(null, trustAll, SecureRandom())
-        builder.sslSocketFactory(sslContext.socketFactory, trustAll[0] as X509TrustManager)
-        builder.hostnameVerifier { _, _ -> true }
+            .build()
     }
 }

--- a/app/src/main/kotlin/com/yunx/app/data/security/CredentialCipher.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/security/CredentialCipher.kt
@@ -1,0 +1,71 @@
+package com.yunx.app.data.security
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+internal interface CredentialCipher {
+    fun encrypt(plaintext: String, purpose: String): String
+    fun decrypt(stored: String, purpose: String): String
+    fun isEncrypted(stored: String): Boolean
+}
+
+/** AES-GCM envelope encryption whose non-exportable key is held by Android Keystore. */
+internal class AndroidKeystoreCredentialCipher : CredentialCipher {
+    override fun encrypt(plaintext: String, purpose: String): String {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, key())
+        cipher.updateAAD(purpose.toByteArray(Charsets.UTF_8))
+        val ciphertext = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+        return listOf(
+            PREFIX,
+            Base64.encodeToString(cipher.iv, Base64.NO_WRAP),
+            Base64.encodeToString(ciphertext, Base64.NO_WRAP)
+        ).joinToString(":")
+    }
+
+    override fun decrypt(stored: String, purpose: String): String {
+        if (!isEncrypted(stored)) return stored
+        val parts = stored.split(':', limit = 4)
+        require(parts.size == 4 && parts[0] == "yunx" && parts[1] == "v1") {
+            "Unsupported encrypted credential format"
+        }
+        val iv = Base64.decode(parts[2], Base64.NO_WRAP)
+        val ciphertext = Base64.decode(parts[3], Base64.NO_WRAP)
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.DECRYPT_MODE, key(), GCMParameterSpec(128, iv))
+        cipher.updateAAD(purpose.toByteArray(Charsets.UTF_8))
+        return cipher.doFinal(ciphertext).toString(Charsets.UTF_8)
+    }
+
+    override fun isEncrypted(stored: String): Boolean = stored.startsWith("$PREFIX:")
+
+    private fun key(): SecretKey {
+        val keyStore = KeyStore.getInstance(KEYSTORE).apply { load(null) }
+        (keyStore.getKey(KEY_ALIAS, null) as? SecretKey)?.let { return it }
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE)
+        generator.init(
+            KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setRandomizedEncryptionRequired(true)
+                .build()
+        )
+        return generator.generateKey()
+    }
+
+    private companion object {
+        const val KEYSTORE = "AndroidKeyStore"
+        const val KEY_ALIAS = "yunx.account.credentials.v1"
+        const val TRANSFORMATION = "AES/GCM/NoPadding"
+        const val PREFIX = "yunx:v1"
+    }
+}

--- a/app/src/main/kotlin/com/yunx/app/ui/MainScreen.kt
+++ b/app/src/main/kotlin/com/yunx/app/ui/MainScreen.kt
@@ -182,8 +182,6 @@ fun MainScreen() {
     val pan123Api = remember { Pan123Api() }
     val db = remember { AppDatabase.get(context) }
     val settings = remember { SettingsRepository(context) }
-    // 启动时同步「忽略 SSL 证书」开关（设置页隐藏菜单持久化，全局客户端即时生效）
-    LaunchedEffect(Unit) { HttpClients.ignoreSsl = settings.ignoreSslCert }
     val repository = remember {
         QuarkAccountRepository(db.quarkAccountDao(), api)
     }

--- a/app/src/main/kotlin/com/yunx/app/ui/login/C139LoginScreen.kt
+++ b/app/src/main/kotlin/com/yunx/app/ui/login/C139LoginScreen.kt
@@ -3,6 +3,7 @@ package com.yunx.app.ui.login
 import android.graphics.Bitmap
 import android.os.Build
 import android.util.Log
+import com.yunx.app.util.LogRedactor
 import android.webkit.CookieManager
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebChromeClient
@@ -101,12 +102,12 @@ fun C139LoginScreen(
             settings.userAgentString = WebSettings.getDefaultUserAgent(context)
             webViewClient = object : WebViewClient() {
                 override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-                    Log.d(TAG, "onPageStarted: $url")
+                    Log.d(TAG, "onPageStarted: ${LogRedactor.url(url)}")
                     isLoading = true
                 }
 
                 override fun onPageFinished(view: WebView?, url: String?) {
-                    Log.d(TAG, "onPageFinished: $url")
+                    Log.d(TAG, "onPageFinished: ${LogRedactor.url(url)}")
                     isLoading = false
                     // 强制覆盖页面 viewport：适配屏幕宽度 + 允许双指缩放（139 移动版页面 viewport 缺失或限制缩放时生效）
                     view?.evaluateJavascript(
@@ -123,7 +124,7 @@ fun C139LoginScreen(
                     request: WebResourceRequest?,
                     error: android.webkit.WebResourceError?
                 ) {
-                    Log.e(TAG, "onReceivedError: code=${error?.errorCode} desc=${error?.description} url=${request?.url}")
+                    Log.e(TAG, "onReceivedError: code=${error?.errorCode} desc=${error?.description} origin=${LogRedactor.url(request?.url)}")
                     isLoading = false
                 }
 
@@ -132,7 +133,7 @@ fun C139LoginScreen(
                     request: WebResourceRequest?,
                     errorResponse: WebResourceResponse?
                 ) {
-                    Log.e(TAG, "onReceivedHttpError: status=${errorResponse?.statusCode} reason=${errorResponse?.reasonPhrase} url=${request?.url}")
+                    Log.e(TAG, "onReceivedHttpError: status=${errorResponse?.statusCode} reason=${errorResponse?.reasonPhrase} origin=${LogRedactor.url(request?.url)}")
                 }
 
                 @RequiresApi(Build.VERSION_CODES.O)

--- a/app/src/main/kotlin/com/yunx/app/ui/login/XunleiVerificationPolicy.kt
+++ b/app/src/main/kotlin/com/yunx/app/ui/login/XunleiVerificationPolicy.kt
@@ -1,0 +1,20 @@
+package com.yunx.app.ui.login
+
+import java.net.URI
+
+/** Origin policy for the Xunlei verification page and its native callback. */
+internal object XunleiVerificationPolicy {
+    fun isTrustedPage(url: String?): Boolean = runCatching {
+        val uri = URI(url ?: return false)
+        val host = uri.host?.lowercase() ?: return false
+        uri.scheme.equals("https", ignoreCase = true) &&
+            (host == "xunlei.com" || host.endsWith(".xunlei.com"))
+    }.getOrDefault(false)
+
+    fun isTrustedCallback(url: String?): Boolean = runCatching {
+        val uri = URI(url ?: return false)
+        uri.scheme.equals("xlaccsdk01", ignoreCase = true) &&
+            uri.host.equals("xunlei.com", ignoreCase = true) &&
+            uri.path == "/callback"
+    }.getOrDefault(false)
+}

--- a/app/src/main/kotlin/com/yunx/app/ui/login/XunleiVerifyWebViewScreen.kt
+++ b/app/src/main/kotlin/com/yunx/app/ui/login/XunleiVerifyWebViewScreen.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.webkit.JavascriptInterface
+import android.webkit.WebResourceRequest
 import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
@@ -28,6 +29,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -38,6 +40,22 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import com.yunx.app.data.network.XunleiConstants
 import com.yunx.app.ui.rememberGlobalSnackbarHostState
+import org.json.JSONObject
+
+private class XunleiJsBridge(
+    private val onSuccess: (String) -> Unit,
+    private val onClose: () -> Unit
+) {
+    @JavascriptInterface
+    fun onVerifyResult(resultJson: String) = onSuccess(resultJson)
+
+    @JavascriptInterface
+    fun close() = onClose()
+}
+
+private fun attachVerificationBridge(webView: WebView, bridge: XunleiJsBridge) {
+    webView.addJavascriptInterface(bridge, "XLJSWebViewBridge")
+}
 
 /**
  * 迅雷验证页应用内承载（V3 · 实测修复）。
@@ -59,19 +77,21 @@ fun XunleiVerifyWebViewScreen(
 ) {
     val context = LocalContext.current
     var isLoading by remember { mutableStateOf(true) }
+    val trustedInitialUrl = remember(verifyUrl) { XunleiVerificationPolicy.isTrustedPage(verifyUrl) }
 
-    val bridge = remember {
-        object {
-            @JavascriptInterface
-            fun onVerifyResult(resultJson: String) {
+    LaunchedEffect(verifyUrl, trustedInitialUrl) {
+        if (!trustedInitialUrl) onResult(false, "untrusted_verify_url")
+    }
+
+    val bridge: XunleiJsBridge = remember(onResult) {
+        XunleiJsBridge(
+            onSuccess = { resultJson ->
                 Handler(Looper.getMainLooper()).post { onResult(true, resultJson) }
-            }
-
-            @JavascriptInterface
-            fun close() {
+            },
+            onClose = {
                 Handler(Looper.getMainLooper()).post { onResult(false, "user_closed") }
             }
-        }
+        )
     }
 
     val webView = remember(verifyUrl) {
@@ -85,30 +105,50 @@ fun XunleiVerifyWebViewScreen(
             settings.loadWithOverviewMode = true
             settings.layoutAlgorithm = WebSettings.LayoutAlgorithm.NARROW_COLUMNS
             settings.userAgentString = XunleiConstants.APP_UA
-            addJavascriptInterface(bridge, "XLJSWebViewBridge")
+            settings.allowFileAccess = false
+            settings.allowContentAccess = false
+            settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+            if (trustedInitialUrl) attachVerificationBridge(this, bridge)
             webViewClient = object : WebViewClient() {
                 override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                     isLoading = true
+                    if (!XunleiVerificationPolicy.isTrustedPage(url)) {
+                        view?.stopLoading()
+                        view?.removeJavascriptInterface("XLJSWebViewBridge")
+                        onResult(false, "untrusted_verify_navigation")
+                    }
                 }
 
                 override fun onPageFinished(view: WebView?, url: String?) {
                     isLoading = false
-                    // 核心修复：主动调用 window.XlCaptcha.init(config) 唤醒页面渲染
-                    view?.evaluateJavascript(buildInitScript(deviceId), null)
+                    if (XunleiVerificationPolicy.isTrustedPage(url)) {
+                        view?.evaluateJavascript(buildInitScript(deviceId), null)
+                    } else {
+                        view?.removeJavascriptInterface("XLJSWebViewBridge")
+                    }
                 }
 
                 override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
-                    if (url != null && url.startsWith("xlaccsdk01://")) {
-                        onResult(true, url)
+                    if (XunleiVerificationPolicy.isTrustedCallback(url)) {
+                        onResult(true, url.orEmpty())
                         return true
                     }
-                    return false
+                    return !XunleiVerificationPolicy.isTrustedPage(url)
+                }
+
+                override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                    val url = request?.url?.toString()
+                    if (XunleiVerificationPolicy.isTrustedCallback(url)) {
+                        onResult(true, url.orEmpty())
+                        return true
+                    }
+                    return !XunleiVerificationPolicy.isTrustedPage(url)
                 }
             }
             webChromeClient = WebChromeClient()
             // 【修复点 1】页面用 parseQueryString(location.href) 读 deviceid，
             // 必须把 deviceid 拼进 URL，否则发短信会报 "deviceid不能为空"。
-            loadUrl(withDeviceId(verifyUrl, deviceId))
+            loadUrl(if (trustedInitialUrl) withDeviceId(verifyUrl, deviceId) else "about:blank")
         }
     }
 
@@ -165,14 +205,17 @@ private fun withDeviceId(url: String, deviceId: String): String {
 private fun buildInitScript(deviceId: String): String {
     val pkg = "ANDROID-com.xunlei.downloadprovider"   // 必须与 reviewurl 里的 appName 一致
     val cv = XunleiConstants.APP_CLIENT_VERSION      // 8.31.0.9726
+    val pkgJs = JSONObject.quote(pkg)
+    val clientVersionJs = JSONObject.quote(cv)
+    val deviceIdJs = JSONObject.quote(deviceId)
     return """
         (function(){
           try {
             window.env = 'android';
             window.appid = '40';
-            window.appName = '$pkg';
-            window.clientVersion = '$cv';
-            window.deviceid = '$deviceId';
+            window.appName = $pkgJs;
+            window.clientVersion = $clientVersionJs;
+            window.deviceid = $deviceIdJs;
             window.platformVersion = '10';
             window.event = 'login3';
           } catch(e) {}
@@ -186,9 +229,9 @@ private fun buildInitScript(deviceId: String): String {
                 }
                 window.XlCaptcha.init({
                   appid: '40',
-                  appName: '$pkg',
-                  clientVersion: '$cv',
-                  deviceid: '$deviceId',
+                  appName: $pkgJs,
+                  clientVersion: $clientVersionJs,
+                  deviceid: $deviceIdJs,
                   event: 'login3',
                   platformVersion: '10',
                   IFRAME_BOX_ID: 'captch-wrap',

--- a/app/src/main/kotlin/com/yunx/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/yunx/app/ui/screens/SettingsScreen.kt
@@ -76,7 +76,6 @@ import androidx.compose.ui.unit.dp
 import com.yunx.app.data.backup.AuthBackupManager
 import com.yunx.app.data.backup.AuthCrypto
 import com.yunx.app.data.download.DownloadSaver
-import com.yunx.app.data.network.HttpClients
 import com.yunx.app.data.prefs.SettingsRepository
 import com.yunx.app.data.update.UpdateChecker
 import com.yunx.app.ui.SnackbarController
@@ -122,10 +121,7 @@ fun SettingsScreen(
     // 下载保存目录（SAF）：本地状态驱动 UI 刷新，同时同步 SharedPreferences
     val settingsRepo = remember { SettingsRepository(context) }
     var downloadDirUri by remember { mutableStateOf(settingsRepo.downloadDirUri) }
-    // 隐藏开发调试：忽略 SSL 证书（抓包用，长按「关于云析」打开菜单）
-    var ignoreSsl by remember { mutableStateOf(settingsRepo.ignoreSslCert) }
     var showDevMenu by remember { mutableStateOf(false) }
-    LaunchedEffect(Unit) { ignoreSsl = settingsRepo.ignoreSslCert }
     // 网络与下载策略（本地状态驱动 UI，同时同步 SharedPreferences）
     var maxConcurrent by remember { mutableStateOf(settingsRepo.maxConcurrentDownloads) }
     var speedLimitBps by remember { mutableStateOf(settingsRepo.downloadSpeedLimit) }
@@ -456,55 +452,13 @@ fun SettingsScreen(
         )
     }
 
-    // 隐藏开发调试菜单（长按「关于云析」打开）：忽略 SSL 证书（抓包调试用）
+    // 隐藏开发调试菜单（长按「关于云析」打开）
     if (showDevMenu) {
         AlertDialog(
             onDismissRequest = { showDevMenu = false },
             title = { Text("开发调试") },
             text = {
                 Column {
-                    val toggleIgnoreSsl = {
-                        ignoreSsl = !ignoreSsl
-                        settingsRepo.ignoreSslCert = ignoreSsl
-                        HttpClients.ignoreSsl = ignoreSsl
-                        SnackbarController.show(
-                            if (ignoreSsl) "已忽略 SSL 证书校验（抓包模式）" else "已恢复 SSL 证书校验"
-                        )
-                    }
-                    val rowShape = MaterialTheme.shapes.medium
-                    val rowInteraction = remember { MutableInteractionSource() }
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(rowShape)
-                            .combinedClickable(
-                                interactionSource = rowInteraction,
-                                indication = ripple(bounded = true),
-                                onClick = toggleIgnoreSsl
-                            ),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(
-                                text = "忽略 SSL 证书",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Medium
-                            )
-                            Text(
-                                text = if (ignoreSsl) "已开启：所有网络请求不校验证书（抓包用）" else "已关闭：正常校验证书",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-                        Switch(checked = ignoreSsl, onCheckedChange = { toggleIgnoreSsl() })
-                    }
-                    Spacer(modifier = Modifier.height(12.dp))
-                    Text(
-                        text = "开启后所有 API 与下载请求将忽略 SSL 证书校验，便于配合抓包调试。请勿在日常使用中开启，存在中间人攻击风险。",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
                     Button(
                         onClick = {
                             showDevMenu = false

--- a/app/src/main/kotlin/com/yunx/app/util/LogExporter.kt
+++ b/app/src/main/kotlin/com/yunx/app/util/LogExporter.kt
@@ -120,7 +120,7 @@ object LogExporter {
             if (lines.isEmpty()) {
                 writer.write("（无输出）\n")
             } else {
-                lines.forEach { writer.write(it); writer.write("\n") }
+                lines.forEach { writer.write(LogRedactor.line(it)); writer.write("\n") }
             }
         } catch (e: Exception) {
             writer.write("（读取日志失败：${e.message}）\n")

--- a/app/src/main/kotlin/com/yunx/app/util/LogRedactor.kt
+++ b/app/src/main/kotlin/com/yunx/app/util/LogRedactor.kt
@@ -1,0 +1,30 @@
+package com.yunx.app.util
+
+import java.net.URI
+
+/** Redacts capability-bearing URL paths, queries, fragments and user info. */
+object LogRedactor {
+    private val absoluteUrl = Regex("""https?://[^\s\"'<>]+""", RegexOption.IGNORE_CASE)
+    private val secretAssignment = Regex(
+        """(?i)\b(cookie|authorization|access[_-]?token|refresh[_-]?token|captcha[_-]?token|bduss|stoken|__puus|__pus|rmkey|signature|sign)\b(\s*[=:]\s*)([^\s,;]+)"""
+    )
+
+    fun url(value: Any?): String {
+        val raw = value?.toString()?.takeIf { it.isNotBlank() } ?: return "<none>"
+        return runCatching {
+            val uri = URI(raw)
+            val scheme = uri.scheme?.lowercase() ?: return@runCatching "<relative-url>"
+            val host = uri.host?.lowercase() ?: return@runCatching "<$scheme-url>"
+            val defaultPort = (scheme == "https" && uri.port == 443) || (scheme == "http" && uri.port == 80)
+            val port = if (uri.port >= 0 && !defaultPort) ":${uri.port}" else ""
+            "$scheme://$host$port"
+        }.getOrDefault("<invalid-url>")
+    }
+
+    fun line(value: String): String {
+        val withoutUrls = absoluteUrl.replace(value) { match -> url(match.value) }
+        return secretAssignment.replace(withoutUrls) { match ->
+            "${match.groupValues[1]}${match.groupValues[2]}<redacted>"
+        }
+    }
+}

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <!-- Android only applies this block when android:debuggable="true". -->
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>

--- a/app/src/test/kotlin/com/yunx/app/data/db/SecureAccountDaosTest.kt
+++ b/app/src/test/kotlin/com/yunx/app/data/db/SecureAccountDaosTest.kt
@@ -1,0 +1,45 @@
+package com.yunx.app.data.db
+
+import com.yunx.app.data.security.CredentialCipher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SecureAccountDaosTest {
+    @Test
+    fun encryptsWritesAndMigratesLegacyPlaintextOnRead() = runBlocking {
+        val raw = FakeQuarkDao(QuarkAccountEntity(cookie = "legacy-secret"))
+        val secure = SecureAccountDaos.quark(raw, FakeCipher())
+
+        assertEquals("legacy-secret", secure.getAccount()?.cookie)
+        assertTrue(raw.value()?.cookie?.startsWith("sealed:") == true)
+        assertFalse(raw.value()?.cookie?.contains("legacy-secret") == true)
+
+        secure.upsert(QuarkAccountEntity(cookie = "new-secret"))
+        assertEquals("new-secret", secure.getAccount()?.cookie)
+        assertFalse(raw.value()?.cookie?.contains("new-secret") == true)
+    }
+
+    private class FakeQuarkDao(initial: QuarkAccountEntity?) : QuarkAccountDao {
+        private val state = MutableStateFlow(initial)
+        fun value(): QuarkAccountEntity? = state.value
+        override fun observeAccount(): Flow<QuarkAccountEntity?> = state
+        override suspend fun upsert(account: QuarkAccountEntity) { state.value = account }
+        override suspend fun getAccount(): QuarkAccountEntity? = state.value
+        override suspend fun clear() { state.value = null }
+    }
+
+    private class FakeCipher : CredentialCipher {
+        override fun encrypt(plaintext: String, purpose: String): String =
+            "sealed:${purpose.reversed()}:${plaintext.reversed()}"
+
+        override fun decrypt(stored: String, purpose: String): String =
+            if (isEncrypted(stored)) stored.substringAfterLast(':').reversed() else stored
+
+        override fun isEncrypted(stored: String): Boolean = stored.startsWith("sealed:")
+    }
+}

--- a/app/src/test/kotlin/com/yunx/app/data/download/DownloadPathPolicyTest.kt
+++ b/app/src/test/kotlin/com/yunx/app/data/download/DownloadPathPolicyTest.kt
@@ -1,0 +1,33 @@
+package com.yunx.app.data.download
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class DownloadPathPolicyTest {
+
+    @Test
+    fun rejectsTraversalComponentsAndAbsolutePaths() {
+        assertNull(DownloadPathPolicy.sanitize("../secret.txt", "fallback"))
+        assertNull(DownloadPathPolicy.sanitize("folder/../secret.txt", "fallback"))
+        assertNull(DownloadPathPolicy.sanitize("folder/./secret.txt", "fallback"))
+        assertNull(DownloadPathPolicy.sanitize("/absolute/secret.txt", "fallback"))
+    }
+
+    @Test
+    fun preservesLegitimateNestedDownload() {
+        val path = DownloadPathPolicy.sanitize("folder/sub/a?.mp4", "fallback")
+        assertEquals("folder/sub", path?.relativeDirectory)
+        assertEquals("a_.mp4", path?.fileName)
+    }
+
+    @Test
+    fun canonicalContainmentRejectsSibling() {
+        val base = File("build/policy-test/downloads")
+        assertTrue(DownloadPathPolicy.isContained(base, File(base, "folder/file.bin")))
+        assertFalse(DownloadPathPolicy.isContained(base, File(base, "../outside.bin")))
+    }
+}

--- a/app/src/test/kotlin/com/yunx/app/data/download/HlsRequestPolicyTest.kt
+++ b/app/src/test/kotlin/com/yunx/app/data/download/HlsRequestPolicyTest.kt
@@ -1,0 +1,45 @@
+package com.yunx.app.data.download
+
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HlsRequestPolicyTest {
+    private val origin = "https://drive.uc.cn/media/master.m3u8".toHttpUrl()
+    private val headers = mapOf(
+        "Cookie" to "session=secret",
+        "Authorization" to "Bearer secret",
+        "Referer" to "https://drive.uc.cn/",
+        "User-Agent" to "YunX"
+    )
+
+    @Test
+    fun retainsCredentialsOnlyForSameOrigin() {
+        val same = HlsRequestPolicy.headersFor(
+            "https://drive.uc.cn/media/1.ts".toHttpUrl(), origin, headers
+        )
+        assertEquals(headers, same)
+
+        val cross = HlsRequestPolicy.headersFor(
+            "https://attacker.example/1.ts".toHttpUrl(), origin, headers
+        )
+        assertFalse(cross.containsKey("Cookie"))
+        assertFalse(cross.containsKey("Authorization"))
+        assertFalse(cross.containsKey("Referer"))
+        assertEquals("YunX", cross["User-Agent"])
+    }
+
+    @Test
+    fun resolvesOnlyHttpsChildren() {
+        assertEquals(
+            "https://drive.uc.cn/media/1.ts",
+            HlsRequestPolicy.resolve(origin, "1.ts")?.toString()
+        )
+        assertNull(HlsRequestPolicy.resolve(origin, "http://attacker.example/1.ts"))
+        assertNull(HlsRequestPolicy.initialUrl("file:///sdcard/a.m3u8"))
+        assertTrue(HlsRequestPolicy.sameOrigin(origin, "https://drive.uc.cn/other".toHttpUrl()))
+    }
+}

--- a/app/src/test/kotlin/com/yunx/app/data/download/HttpRangePolicyTest.kt
+++ b/app/src/test/kotlin/com/yunx/app/data/download/HttpRangePolicyTest.kt
@@ -1,0 +1,26 @@
+package com.yunx.app.data.download
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HttpRangePolicyTest {
+    @Test
+    fun parsesAndMatchesExactRange() {
+        val range = HttpRangePolicy.parse("bytes 100-199/1000")
+        assertEquals(100L, range?.start)
+        assertEquals(199L, range?.end)
+        assertEquals(1000L, range?.total)
+        assertTrue(HttpRangePolicy.matches("bytes 100-199/1000", 100, 199))
+        assertFalse(HttpRangePolicy.matches("bytes 0-99/1000", 100, 199))
+    }
+
+    @Test
+    fun rejectsMalformedOrImpossibleRanges() {
+        assertNull(HttpRangePolicy.parse("bytes 10-9/100"))
+        assertNull(HttpRangePolicy.parse("bytes 0-100/100"))
+        assertFalse(HttpRangePolicy.matches(null, 0, 0))
+    }
+}

--- a/app/src/test/kotlin/com/yunx/app/ui/login/XunleiVerificationPolicyTest.kt
+++ b/app/src/test/kotlin/com/yunx/app/ui/login/XunleiVerificationPolicyTest.kt
@@ -1,0 +1,22 @@
+package com.yunx.app.ui.login
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class XunleiVerificationPolicyTest {
+    @Test
+    fun acceptsOnlyXunleiHttpsOrigins() {
+        assertTrue(XunleiVerificationPolicy.isTrustedPage("https://verify.xunlei.com/a?token=1"))
+        assertFalse(XunleiVerificationPolicy.isTrustedPage("http://verify.xunlei.com/a"))
+        assertFalse(XunleiVerificationPolicy.isTrustedPage("https://xunlei.com.attacker.example/a"))
+        assertFalse(XunleiVerificationPolicy.isTrustedPage("javascript:alert(1)"))
+    }
+
+    @Test
+    fun acceptsOnlyExactNativeCallback() {
+        assertTrue(XunleiVerificationPolicy.isTrustedCallback("xlaccsdk01://xunlei.com/callback?state=harbor"))
+        assertFalse(XunleiVerificationPolicy.isTrustedCallback("xlaccsdk01://attacker.example/callback"))
+        assertFalse(XunleiVerificationPolicy.isTrustedCallback("xlaccsdk01://xunlei.com/other"))
+    }
+}

--- a/app/src/test/kotlin/com/yunx/app/util/LogRedactorTest.kt
+++ b/app/src/test/kotlin/com/yunx/app/util/LogRedactorTest.kt
@@ -1,0 +1,33 @@
+package com.yunx.app.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class LogRedactorTest {
+    @Test
+    fun removesPathQueryFragmentAndUserInfo() {
+        val redacted = LogRedactor.url("https://user:pass@cdn.example:8443/private/a?sign=secret#token")
+        assertEquals("https://cdn.example:8443", redacted)
+        assertFalse(redacted.contains("secret"))
+        assertFalse(redacted.contains("private"))
+        assertFalse(redacted.contains("user"))
+    }
+
+    @Test
+    fun handlesInvalidAndRelativeValues() {
+        assertEquals("<relative-url>", LogRedactor.url("segment.ts?token=secret"))
+        assertEquals("<none>", LogRedactor.url(null))
+    }
+
+    @Test
+    fun redactsUrlsAndKnownSecretAssignmentsFromExportedLines() {
+        val line = LogRedactor.line(
+            "download https://cdn.example/private.bin?sign=url-secret Cookie=session-secret access_token=jwt-secret"
+        )
+        assertFalse(line.contains("url-secret"))
+        assertFalse(line.contains("session-secret"))
+        assertFalse(line.contains("jwt-secret"))
+        assertEquals("download https://cdn.example Cookie=<redacted> access_token=<redacted>", line)
+    }
+}


### PR DESCRIPTION
## 变更摘要

- 收紧 HLS 请求边界：仅允许 HTTPS，跨域请求剥离 Cookie/Authorization 等敏感头，并限制重定向、播放列表、分片和总下载量
- 加固下载保存与断点续传：阻止路径穿越和同名覆盖，严格校验 Content-Range，完整下载前清空旧前缀
- 使用 Android Keystore + AES-GCM 加密六类网盘凭证及持久化下载请求头，并透明迁移旧明文记录
- 移除信任任意 TLS 证书/主机名的实现；通过 Android network security config 仅允许 Debug 包信任用户 CA，Release 保持系统 CA 校验；增加 URL/凭证日志脱敏
- 将迅雷验证 WebView 的页面、回调和 JavaScript bridge 限定到可信来源

## 验证

- `testDebugUnitTest`：16 tests，0 failures
- `assembleDebug`：通过
- `assembleRelease` / release lint vital：通过
- `git diff --check`：通过
- 全量 `lintDebug` 仍被仓库已有的 145 个问题阻断；首个为未修改的 `BaiduApi.kt` SuspiciousIndentation，本次新增代码无新增 Lint error

## 兼容性说明

- 旧版 Room 明文凭证会在首次读取时自动加密迁移；Keystore 数据失效时清理对应登录记录，避免继续使用不可解密数据
- 同名下载改为生成新名称，不再覆盖或预删已有文件
- 未包含本地 `work/` 工具链目录