### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      # 显式安装 Android SDK（compileSdk=36 / build-tools），避免依赖 runner 预装版本或 AGP 现场下载
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Cache Gradle and dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # 完整构建 debug APK（验证编译链路 + 产出可安装包）
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest
+
+      # 上传 debug APK 产物（PR 评论 / Actions 页面可下载）
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # CI访问阿里云镜像会 502：跳过国内镜像，直接走 Google/Maven Central 官方源
+    env:
+      YUNX_USE_MIRROR: "false"
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Android 构建输出
 /build/
+/.kotlin/
 /app/build/
 /captures
 .externalNativeBuild/

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,15 @@
+// 国内镜像开关：CI（GitHub Actions，阿里云镜像不可达/慢）设 YUNX_USE_MIRROR=false 走官方源；
+// 本地（AndroidIDE）不设置该变量时默认用阿里云镜像加速（国内可直连）。
+val useMirror = System.getenv("YUNX_USE_MIRROR") != "false"
+
 pluginManagement {
     repositories {
-        // 阿里云镜像：国内可直连，优先使用，避免去连被墙的 Gradle Plugin Portal
-        maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") } // 镜像 Gradle Plugin Portal（KSP 插件标记在这里）
-        maven { url = uri("https://maven.aliyun.com/repository/google") }         // 镜像 Google Maven
-        maven { url = uri("https://maven.aliyun.com/repository/public") }          // 镜像 Maven Central 等公共仓
+        if (useMirror) {
+            // 阿里云镜像：国内可直连，优先使用，避免去连被墙的 Gradle Plugin Portal
+            maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") } // 镜像 Gradle Plugin Portal（KSP 插件标记在这里）
+            maven { url = uri("https://maven.aliyun.com/repository/google") }         // 镜像 Google Maven
+            maven { url = uri("https://maven.aliyun.com/repository/public") }          // 镜像 Maven Central 等公共仓
+        }
         // 兜底（若上面镜像不可用，仍会回退到这里）
         gradlePluginPortal()
         google()
@@ -14,8 +20,10 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        maven { url = uri("https://maven.aliyun.com/repository/google") }
-        maven { url = uri("https://maven.aliyun.com/repository/public") }
+        if (useMirror) {
+            maven { url = uri("https://maven.aliyun.com/repository/google") }
+            maven { url = uri("https://maven.aliyun.com/repository/public") }
+        }
         google()
         mavenCentral()
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,8 @@
-// 国内镜像开关：CI（GitHub Actions，阿里云镜像不可达/慢）设 YUNX_USE_MIRROR=false 走官方源；
-// 本地（AndroidIDE）不设置该变量时默认用阿里云镜像加速（国内可直连）。
-val useMirror = System.getenv("YUNX_USE_MIRROR") != "false"
-
+// 国内镜像开关：CI（GitHub Actions，阿里云镜像 502 不可达）设 YUNX_USE_MIRROR=false 走官方源；
+// 本地（AndroidIDE）不设置该变量时默认用阿里云镜像加速。注意：pluginManagement 块作用域独立，不能引用顶层 val，故内联读取。
 pluginManagement {
     repositories {
-        if (useMirror) {
+        if (System.getenv("YUNX_USE_MIRROR") != "false") {
             // 阿里云镜像：国内可直连，优先使用，避免去连被墙的 Gradle Plugin Portal
             maven { url = uri("https://maven.aliyun.com/repository/gradle-plugin") } // 镜像 Gradle Plugin Portal（KSP 插件标记在这里）
             maven { url = uri("https://maven.aliyun.com/repository/google") }         // 镜像 Google Maven
@@ -20,7 +18,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        if (useMirror) {
+        if (System.getenv("YUNX_USE_MIRROR") != "false") {
             maven { url = uri("https://maven.aliyun.com/repository/google") }
             maven { url = uri("https://maven.aliyun.com/repository/public") }
         }


### PR DESCRIPTION
仓库目前没有 CI 自动化，代码合并前只能靠本地手动构建和测试，容易漏掉编译错误或测试失败。本次添加 GitHub Actions 工作流，实现基本的持续集成检查。

改动内容

· 新增 .github/workflows/ci.yml
· 配置触发条件：push 到 master 以及所有目标为 master 的 PR
· 构建流程包含：
  · 使用 JDK 17 + Android SDK 环境
  · 缓存 Gradle 依赖，加速后续构建
  · 执行 assembleDebug 构建 debug APK
  · 执行 testDebugUnitTest 跑单元测试
  · 上传 debug APK 作为构建产物（artifact）

验证方式

· 本地已确认 assembleDebug 和 testDebugUnitTest 通过
