### PR TITLE
fix: 修复网盘页刷新掉帧、优化认证导入导出加载反馈

### DIFF
--- a/app/src/main/kotlin/com/yunx/app/data/db/SecureAccountDaos.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/db/SecureAccountDaos.kt
@@ -1,16 +1,26 @@
 package com.yunx.app.data.db
 
 import com.yunx.app.data.security.CredentialCipher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 
-/** DAO decorators: plaintext is exposed only in memory; every database write is encrypted. */
+/**
+ * DAO decorators: plaintext is exposed only in memory; every database write is encrypted.
+ *
+ * 性能修复（v1.2.6）：解密/加密全部切到 `Dispatchers.IO`。
+ * 之前的实现里 Room suspend 查询返回后，`decrypt*` 在**调用方协程上下文**（viewModelScope = 主线程）执行
+ * AndroidKeyStore（Binder IPC，单次 30~75ms）→ 网盘页下拉刷新时 6 平台并发把主线程占死 400~500ms → 全应用掉帧。
+ */
 internal object SecureAccountDaos {
     fun quark(raw: QuarkAccountDao, cipher: CredentialCipher): QuarkAccountDao = object : QuarkAccountDao {
         override fun observeAccount(): Flow<QuarkAccountEntity?> = raw.observeAccount().map { value ->
             value?.let { decryptQuark(raw, cipher, it) }
         }
-        override suspend fun upsert(account: QuarkAccountEntity) = raw.upsert(encryptQuark(cipher, account))
+        override suspend fun upsert(account: QuarkAccountEntity) = withContext(Dispatchers.IO) {
+            raw.upsert(encryptQuark(cipher, account))
+        }
         override suspend fun getAccount(): QuarkAccountEntity? = raw.getAccount()?.let { decryptQuark(raw, cipher, it) }
         override suspend fun clear() = raw.clear()
     }
@@ -19,7 +29,9 @@ internal object SecureAccountDaos {
         override fun observeAccount(): Flow<UCAccountEntity?> = raw.observeAccount().map { value ->
             value?.let { decryptUc(raw, cipher, it) }
         }
-        override suspend fun upsert(account: UCAccountEntity) = raw.upsert(encryptUc(cipher, account))
+        override suspend fun upsert(account: UCAccountEntity) = withContext(Dispatchers.IO) {
+            raw.upsert(encryptUc(cipher, account))
+        }
         override suspend fun getAccount(): UCAccountEntity? = raw.getAccount()?.let { decryptUc(raw, cipher, it) }
         override suspend fun clear() = raw.clear()
     }
@@ -28,7 +40,9 @@ internal object SecureAccountDaos {
         override fun observeAccount(): Flow<BaiduAccountEntity?> = raw.observeAccount().map { value ->
             value?.let { decryptBaidu(raw, cipher, it) }
         }
-        override suspend fun upsert(account: BaiduAccountEntity) = raw.upsert(encryptBaidu(cipher, account))
+        override suspend fun upsert(account: BaiduAccountEntity) = withContext(Dispatchers.IO) {
+            raw.upsert(encryptBaidu(cipher, account))
+        }
         override suspend fun getAccount(): BaiduAccountEntity? = raw.getAccount()?.let { decryptBaidu(raw, cipher, it) }
         override suspend fun clear() = raw.clear()
     }
@@ -37,7 +51,9 @@ internal object SecureAccountDaos {
         override fun observeAccount(): Flow<C139AccountEntity?> = raw.observeAccount().map { value ->
             value?.let { decryptC139(raw, cipher, it) }
         }
-        override suspend fun upsert(account: C139AccountEntity) = raw.upsert(encryptC139(cipher, account))
+        override suspend fun upsert(account: C139AccountEntity) = withContext(Dispatchers.IO) {
+            raw.upsert(encryptC139(cipher, account))
+        }
         override suspend fun getAccount(): C139AccountEntity? = raw.getAccount()?.let { decryptC139(raw, cipher, it) }
         override suspend fun clear() = raw.clear()
     }
@@ -46,7 +62,9 @@ internal object SecureAccountDaos {
         override fun observeAccount(): Flow<Pan123AccountEntity?> = raw.observeAccount().map { value ->
             value?.let { decryptPan123(raw, cipher, it) }
         }
-        override suspend fun upsert(account: Pan123AccountEntity) = raw.upsert(encryptPan123(cipher, account))
+        override suspend fun upsert(account: Pan123AccountEntity) = withContext(Dispatchers.IO) {
+            raw.upsert(encryptPan123(cipher, account))
+        }
         override suspend fun getAccount(): Pan123AccountEntity? = raw.getAccount()?.let { decryptPan123(raw, cipher, it) }
         override suspend fun clear() = raw.clear()
     }
@@ -55,63 +73,77 @@ internal object SecureAccountDaos {
         override fun observeAccount(): Flow<XunleiAccountEntity?> = raw.observeAccount().map { value ->
             value?.let { decryptXunlei(raw, cipher, it) }
         }
-        override suspend fun upsert(account: XunleiAccountEntity) = raw.upsert(encryptXunlei(cipher, account))
+        override suspend fun upsert(account: XunleiAccountEntity) = withContext(Dispatchers.IO) {
+            raw.upsert(encryptXunlei(cipher, account))
+        }
         override suspend fun getAccount(): XunleiAccountEntity? = raw.getAccount()?.let { decryptXunlei(raw, cipher, it) }
         override suspend fun clear() = raw.clear()
     }
 
     private suspend fun decryptQuark(raw: QuarkAccountDao, cipher: CredentialCipher, stored: QuarkAccountEntity): QuarkAccountEntity? =
-        decryptOrClear(raw::clear) {
-            val plain = stored.copy(cookie = cipher.decrypt(stored.cookie, "quark.cookie"))
-            if (!cipher.isEncrypted(stored.cookie)) raw.upsert(encryptQuark(cipher, plain))
-            plain
+        withContext(Dispatchers.IO) {
+            decryptOrClear(raw::clear) {
+                val plain = stored.copy(cookie = cipher.decrypt(stored.cookie, "quark.cookie"))
+                if (!cipher.isEncrypted(stored.cookie)) raw.upsert(encryptQuark(cipher, plain))
+                plain
+            }
         }
 
     private suspend fun decryptUc(raw: UCAccountDao, cipher: CredentialCipher, stored: UCAccountEntity): UCAccountEntity? =
-        decryptOrClear(raw::clear) {
-            val plain = stored.copy(cookie = cipher.decrypt(stored.cookie, "uc.cookie"))
-            if (!cipher.isEncrypted(stored.cookie)) raw.upsert(encryptUc(cipher, plain))
-            plain
+        withContext(Dispatchers.IO) {
+            decryptOrClear(raw::clear) {
+                val plain = stored.copy(cookie = cipher.decrypt(stored.cookie, "uc.cookie"))
+                if (!cipher.isEncrypted(stored.cookie)) raw.upsert(encryptUc(cipher, plain))
+                plain
+            }
         }
 
     private suspend fun decryptBaidu(raw: BaiduAccountDao, cipher: CredentialCipher, stored: BaiduAccountEntity): BaiduAccountEntity? =
-        decryptOrClear(raw::clear) {
-            val plain = stored.copy(cookie = cipher.decrypt(stored.cookie, "baidu.cookie"))
-            if (!cipher.isEncrypted(stored.cookie)) raw.upsert(encryptBaidu(cipher, plain))
-            plain
+        withContext(Dispatchers.IO) {
+            decryptOrClear(raw::clear) {
+                val plain = stored.copy(cookie = cipher.decrypt(stored.cookie, "baidu.cookie"))
+                if (!cipher.isEncrypted(stored.cookie)) raw.upsert(encryptBaidu(cipher, plain))
+                plain
+            }
         }
 
     private suspend fun decryptC139(raw: C139AccountDao, cipher: CredentialCipher, stored: C139AccountEntity): C139AccountEntity? =
-        decryptOrClear(raw::clear) {
-            val plain = stored.copy(
-                cookie = cipher.decrypt(stored.cookie, "c139.cookie"),
-                authorization = cipher.decrypt(stored.authorization, "c139.authorization")
-            )
-            if (!cipher.isEncrypted(stored.cookie) || !cipher.isEncrypted(stored.authorization)) {
-                raw.upsert(encryptC139(cipher, plain))
+        withContext(Dispatchers.IO) {
+            decryptOrClear(raw::clear) {
+                val plain = stored.copy(
+                    cookie = cipher.decrypt(stored.cookie, "c139.cookie"),
+                    authorization = cipher.decrypt(stored.authorization, "c139.authorization")
+                )
+                if (!cipher.isEncrypted(stored.cookie) || !cipher.isEncrypted(stored.authorization)) {
+                    raw.upsert(encryptC139(cipher, plain))
+                }
+                plain
             }
-            plain
         }
 
     private suspend fun decryptPan123(raw: Pan123AccountDao, cipher: CredentialCipher, stored: Pan123AccountEntity): Pan123AccountEntity? =
-        decryptOrClear(raw::clear) {
-            val plain = stored.copy(accessToken = cipher.decrypt(stored.accessToken, "pan123.accessToken"))
-            if (!cipher.isEncrypted(stored.accessToken)) raw.upsert(encryptPan123(cipher, plain))
-            plain
+        withContext(Dispatchers.IO) {
+            decryptOrClear(raw::clear) {
+                val plain = stored.copy(accessToken = cipher.decrypt(stored.accessToken, "pan123.accessToken"))
+                if (!cipher.isEncrypted(stored.accessToken)) raw.upsert(encryptPan123(cipher, plain))
+                plain
+            }
         }
 
     private suspend fun decryptXunlei(raw: XunleiAccountDao, cipher: CredentialCipher, stored: XunleiAccountEntity): XunleiAccountEntity? =
-        decryptOrClear(raw::clear) {
-            val plain = stored.copy(
-                accessToken = cipher.decrypt(stored.accessToken, "xunlei.accessToken"),
-                refreshToken = cipher.decrypt(stored.refreshToken, "xunlei.refreshToken"),
-                deviceId = cipher.decrypt(stored.deviceId, "xunlei.deviceId"),
-                captchaToken = cipher.decrypt(stored.captchaToken, "xunlei.captchaToken")
-            )
-            if (listOf(stored.accessToken, stored.refreshToken, stored.deviceId, stored.captchaToken).any { !cipher.isEncrypted(it) }) {
-                raw.upsert(encryptXunlei(cipher, plain))
+        withContext(Dispatchers.IO) {
+            decryptOrClear(raw::clear) {
+                val plain = stored.copy(
+                    accessToken = cipher.decrypt(stored.accessToken, "xunlei.accessToken"),
+                    refreshToken = cipher.decrypt(stored.refreshToken, "xunlei.refreshToken"),
+                    deviceId = cipher.decrypt(stored.deviceId, "xunlei.deviceId"),
+                    captchaToken = cipher.decrypt(stored.captchaToken, "xunlei.captchaToken")
+                )
+                if (listOf(stored.accessToken, stored.refreshToken, stored.deviceId, stored.captchaToken).any { !cipher.isEncrypted(it) }) {
+                    raw.upsert(encryptXunlei(cipher, plain))
+                }
+                plain
             }
-            plain
         }
 
     private fun encryptQuark(cipher: CredentialCipher, value: QuarkAccountEntity) =

--- a/app/src/main/kotlin/com/yunx/app/data/security/CredentialCipher.kt
+++ b/app/src/main/kotlin/com/yunx/app/data/security/CredentialCipher.kt
@@ -15,8 +15,17 @@ internal interface CredentialCipher {
     fun isEncrypted(stored: String): Boolean
 }
 
-/** AES-GCM envelope encryption whose non-exportable key is held by Android Keystore. */
+/**
+ * AES-GCM envelope encryption whose non-exportable key is held by Android Keystore.
+ *
+ * 性能优化：密钥首次从 Keystore 加载后缓存复用（AndroidKeyStore 每次 KeyStore.load+getKey
+ * 都是 Binder IPC，缓存后避免每次解密/加密都重复走 IPC）。
+ */
 internal class AndroidKeystoreCredentialCipher : CredentialCipher {
+
+    @Volatile
+    private var cachedKey: SecretKey? = null
+
     override fun encrypt(plaintext: String, purpose: String): String {
         val cipher = Cipher.getInstance(TRANSFORMATION)
         cipher.init(Cipher.ENCRYPT_MODE, key())
@@ -46,20 +55,29 @@ internal class AndroidKeystoreCredentialCipher : CredentialCipher {
     override fun isEncrypted(stored: String): Boolean = stored.startsWith("$PREFIX:")
 
     private fun key(): SecretKey {
-        val keyStore = KeyStore.getInstance(KEYSTORE).apply { load(null) }
-        (keyStore.getKey(KEY_ALIAS, null) as? SecretKey)?.let { return it }
-        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE)
-        generator.init(
-            KeyGenParameterSpec.Builder(
-                KEY_ALIAS,
-                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        cachedKey?.let { return it }
+        synchronized(this) {
+            cachedKey?.let { return it }
+            val keyStore = KeyStore.getInstance(KEYSTORE).apply { load(null) }
+            (keyStore.getKey(KEY_ALIAS, null) as? SecretKey)?.let { key ->
+                cachedKey = key
+                return key
+            }
+            val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE)
+            generator.init(
+                KeyGenParameterSpec.Builder(
+                    KEY_ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                )
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setRandomizedEncryptionRequired(true)
+                    .build()
             )
-                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                .setRandomizedEncryptionRequired(true)
-                .build()
-        )
-        return generator.generateKey()
+            val key = generator.generateKey()
+            cachedKey = key
+            return key
+        }
     }
 
     private companion object {

--- a/app/src/main/kotlin/com/yunx/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/yunx/app/ui/screens/SettingsScreen.kt
@@ -11,6 +11,7 @@ import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -52,6 +53,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -113,6 +115,9 @@ fun SettingsScreen(
     // 网盘认证导入：加密文件内容（非空时弹解密密码框）
     var pendingImportContent by remember { mutableStateOf<String?>(null) }
     var showImportAuthDialog by remember { mutableStateOf(false) }
+    // 导出/导入处理中（PBKDF2 21万次迭代派生密钥，偶发 1~3s，期间显示加载弹窗）
+    var isExporting by remember { mutableStateOf(false) }
+    var isImporting by remember { mutableStateOf(false) }
     // 本地状态：修改后立即刷新 UI，同时同步外部保存值
     var threads by remember { mutableStateOf(downloadThreads) }
     LaunchedEffect(downloadThreads) { threads = downloadThreads }
@@ -160,26 +165,31 @@ fun SettingsScreen(
     ) { uri ->
         if (uri != null) {
             scope.launch {
-                val text = runCatching {
-                    context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
-                }.getOrNull()
-                if (text == null) {
-                    SnackbarController.show("读取文件失败")
-                    return@launch
-                }
-                if (AuthCrypto.isEncrypted(text)) {
-                    // 加密备份：弹解密密码框
-                    pendingImportContent = text
-                    showImportAuthDialog = true
-                } else {
-                    // 明文备份：直接导入
-                    val count = runCatching {
-                        withContext(Dispatchers.IO) { backupManager.importJson(text) }
-                    }.getOrElse { e ->
-                        SnackbarController.show("导入失败：${e.message}")
+                isImporting = true
+                try {
+                    val text = runCatching {
+                        context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+                    }.getOrNull()
+                    if (text == null) {
+                        SnackbarController.show("读取文件失败")
                         return@launch
                     }
-                    SnackbarController.show("已恢复 $count 个平台的认证信息")
+                    if (AuthCrypto.isEncrypted(text)) {
+                        // 加密备份：关闭加载弹窗，弹解密密码框（解密在确认后执行）
+                        pendingImportContent = text
+                        showImportAuthDialog = true
+                    } else {
+                        // 明文备份：直接导入
+                        val count = runCatching {
+                            withContext(Dispatchers.IO) { backupManager.importJson(text) }
+                        }.getOrElse { e ->
+                            SnackbarController.show("导入失败：${e.message}")
+                            return@launch
+                        }
+                        SnackbarController.show("已恢复 $count 个平台的认证信息")
+                    }
+                } finally {
+                    isImporting = false
                 }
             }
         }
@@ -576,25 +586,30 @@ fun SettingsScreen(
             onDismiss = { showExportAuthDialog = false },
             onConfirm = { password, onlyLoggedIn ->
                 showExportAuthDialog = false
+                isExporting = true
                 scope.launch {
-                    val content = runCatching {
-                        withContext(Dispatchers.IO) { backupManager.export(password, onlyLoggedIn) }
-                    }.getOrNull()
-                    if (content == null) {
-                        SnackbarController.show("导出失败")
-                        return@launch
-                    }
-                    val encrypted = true
-                    val saved = withContext(Dispatchers.IO) {
-                        backupManager.saveToDownloads(context, content, encrypted)
-                    }
-                    SnackbarController.show(
-                        if (saved) {
-                            if (encrypted) "已加密导出到下载目录" else "已导出到下载目录"
-                        } else {
-                            "导出失败"
+                    try {
+                        val content = runCatching {
+                            withContext(Dispatchers.IO) { backupManager.export(password, onlyLoggedIn) }
+                        }.getOrNull()
+                        if (content == null) {
+                            SnackbarController.show("导出失败")
+                            return@launch
                         }
-                    )
+                        val encrypted = true
+                        val saved = withContext(Dispatchers.IO) {
+                            backupManager.saveToDownloads(context, content, encrypted)
+                        }
+                        SnackbarController.show(
+                            if (saved) {
+                                if (encrypted) "已加密导出到下载目录" else "已导出到下载目录"
+                            } else {
+                                "导出失败"
+                            }
+                        )
+                    } finally {
+                        isExporting = false
+                    }
                 }
             }
         )
@@ -612,22 +627,31 @@ fun SettingsScreen(
                 val content = pendingImportContent
                 pendingImportContent = null
                 if (content != null) {
+                    isImporting = true
                     scope.launch {
-                        val count = try {
-                            withContext(Dispatchers.IO) { backupManager.import(content, password) }
-                        } catch (e: javax.crypto.AEADBadTagException) {
-                            SnackbarController.show("密码错误，解密失败")
-                            return@launch
-                        } catch (e: Exception) {
-                            SnackbarController.show("导入失败：${e.message}")
-                            return@launch
+                        try {
+                            val count = try {
+                                withContext(Dispatchers.IO) { backupManager.import(content, password) }
+                            } catch (e: javax.crypto.AEADBadTagException) {
+                                SnackbarController.show("密码错误，解密失败")
+                                return@launch
+                            } catch (e: Exception) {
+                                SnackbarController.show("导入失败：${e.message}")
+                                return@launch
+                            }
+                            SnackbarController.show("已恢复 $count 个平台的认证信息")
+                        } finally {
+                            isImporting = false
                         }
-                        SnackbarController.show("已恢复 $count 个平台的认证信息")
                     }
                 }
             }
         )
     }
+
+    // 导出/导入处理中：转圈加载弹窗（PBKDF2 派生密钥耗时较长，避免用户以为界面卡死）
+    if (isExporting) OperationLoadingDialog("正在导出认证…")
+    if (isImporting) OperationLoadingDialog("正在导入认证…")
 
     // 最大同时下载任务数
     if (showConcurrencyDialog) {
@@ -933,6 +957,25 @@ private fun ImportAuthDialog(
         dismissButton = {
             TextButton(onClick = onDismiss) { Text("取消") }
         }
+    )
+}
+
+/** 操作处理中弹窗：转圈加载 + 提示文案，禁止关闭（防止中途取消导致导入/导出状态不一致） */
+@Composable
+private fun OperationLoadingDialog(message: String) {
+    AlertDialog(
+        onDismissRequest = {},
+        title = { Text(message) },
+        text = {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        },
+        confirmButton = {},
+        dismissButton = {}
     )
 }
 


### PR DESCRIPTION
## 概述

合并两个独立改动：

1. **修复网盘页下拉刷新时整个应用掉帧**（性能问题，v1.2.5 后引入的回归）；
2. **设置页认证导入/导出增加处理中加载弹窗**（交互反馈问题）。

两者互相独立，可分别 review；均已完成真机实测验证。

---

## Part 1：修复网盘页下拉刷新整体掉帧

### 问题

v1.2.5 之后（b71a550 安全加固引入凭证字段加密），网盘主页下拉刷新时**整个应用明显掉帧**。

实测日志证据（vivo V2065A / Android 10）：
- 6 平台取凭据（cookie/token）解密全部跑在 `main` 线程，单次 AndroidKeyStore 操作 30~75ms（Binder IPC）
- 主线程被连续阻塞 **400~500ms**（主线程探针：计划 50ms 实际 516ms）
- 刷新期间最大帧间隔 **194~237ms**（一次丢 12~14 帧）

### 根因

1. `SecureAccountDaos.getAccount()` 的 Room suspend 查询返回后，`decrypt*` 在**调用方协程上下文**（`viewModelScope` = 主线程）执行；
2. `CredentialCipher.key()` 每次加密/解密都重复执行 `KeyStore.load + getKey`（每次都是 Binder IPC），密钥完全未缓存。

### 修复

- **`SecureAccountDaos`**：6 平台（夸克/UC/迅雷/百度/139/123）的 `getAccount()` / `observeAccount()` 解密、`upsert()` 加密全部包 `withContext(Dispatchers.IO)`，主线程不再触碰 Keystore；
- **`CredentialCipher`**：`cachedKey` 缓存 SecretKey（`@Volatile` + 双重检查锁），删除每次解密的重复 Binder IPC。

### 验证

解密线程从 `main` 变为 IO worker；主线程探针不再出现阻塞；帧间隔恢复到 ~16ms。一处修改，DriveQuota 刷新、6 平台浏览、登录保存、下载器全部受益。

### 涉及文件

- `app/src/main/kotlin/com/yunx/app/data/db/SecureAccountDaos.kt`
- `app/src/main/kotlin/com/yunx/app/data/security/CredentialCipher.kt`

---

## Part 2：认证导入导出增加处理中加载弹窗

### 问题

设置页「导出/导入网盘认证」点击确定后，要等好几秒才提示成功/失败，**期间无任何加载反馈**，用户以为界面卡死。

### 根因

`AuthCrypto` 使用 PBKDF2WithHmacSHA256 **210,000 次迭代**派生密钥（防暴力破解的安全设计，加密/解密各一次），低端机上单次派生耗时 1~3 秒。操作本身在 `Dispatchers.IO` 不阻塞 UI，但缺少处理中反馈。

### 改动

- 新增 `OperationLoadingDialog`：转圈 + 提示文案的加载弹窗，`onDismissRequest = {}` **禁止关闭**（防止中途取消导致导入/导出状态不一致）；
- **导出**：点「导出」→ 立即显示「正在导出认证…」→ 完成/失败后关闭并 Snackbar 结果；
- **加密导入**：点「解密并导入」→ 立即显示「正在导入认证…」→ 成功/密码错误/异常后关闭并提示；
- **明文导入**：选完文件读取+导入期间同样显示加载弹窗（加密文件则收起加载后弹密码框）；
- 全部 `try/finally` 兜底，保证任何分支都不会残留弹窗遮挡界面。

### 说明

PBKDF2 21 万次迭代参数未改动（安全权衡保持原样）；如需降低迭代换取速度，可后续单独讨论向后兼容方案。

### 涉及文件

- `app/src/main/kotlin/com/yunx/app/ui/screens/SettingsScreen.kt`

---

## 验证清单

- [x] 网盘主页下拉刷新 2~3 次：UI 流畅无掉帧
- [x] logcat 确认解密线程为 IO worker（非 `main`）
- [x] 导出认证：点确定立即出现加载弹窗，完成/失败后正常提示
- [x] 加密导入：密码正确恢复、密码错误提示、异常不残留弹窗
- [x] 明文导入：加载反馈正常